### PR TITLE
HTTP/2 and HTTPS support

### DIFF
--- a/Dockerfile.h2-proxy
+++ b/Dockerfile.h2-proxy
@@ -1,0 +1,17 @@
+FROM alpine:latest
+
+RUN apk add --no-cache openssl
+
+# Use this self-generated certificate only in dev, IT IS NOT SECURE!
+RUN openssl genrsa -des3 -passout pass:NotSecure -out server.pass.key 2048
+RUN openssl rsa -passin pass:NotSecure -in server.pass.key -out server.key
+RUN rm server.pass.key
+RUN openssl req -new -passout pass:NotSecure -key server.key -out server.csr \
+    -subj '/C=SS/ST=SS/L=Gotham City/O=Symfony/CN=localhost'
+RUN openssl x509 -req -sha256 -days 365 -in server.csr -signkey server.key -out server.crt
+
+FROM httpd:2.4-alpine
+
+COPY --from=0 server.key /usr/local/apache2/conf/server.key
+COPY --from=0 server.crt /usr/local/apache2/conf/server.crt
+COPY ./docker/httpd/httpd.conf /usr/local/apache2/conf/httpd.conf

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
       - /srv/app/var/cache/
       - /srv/app/var/logs/
       - /srv/app/var/sessions/
-      - /srv/app/vendor/
 
   nginx:
     build:
@@ -24,3 +23,13 @@ services:
       - ./public:/srv/app/public:ro
     ports:
       - '80:80'
+
+  # This HTTP/2 proxy is not secure: it should only be used in dev
+  h2-proxy:
+    build:
+      context: .
+      dockerfile: ./Dockerfile.h2-proxy
+    volumes:
+      - ./docker/httpd/httpd.conf:/usr/local/apache2/conf/httpd.conf:ro
+    ports:
+      - '443:443'

--- a/docker/app/docker-entrypoint.sh
+++ b/docker/app/docker-entrypoint.sh
@@ -7,10 +7,13 @@ if [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
-    # The first time volumes are mounted, dependencies need to be reinstalled
+    # The first time volumes are mounted, the project needs to be recreated
     if [ ! -f composer.json ]; then
-        rm -Rf vendor/*
-        php -r "copy('$SKELETON_COMPOSER_JSON', 'composer.json');"
+        composer create-project "symfony/skeleton" tmp --stability=$STABILITY --prefer-dist --no-progress --no-interaction
+        cp -Rp tmp/. .
+        rm -Rf tmp/
+    elif [ "$APP_ENV" != 'prod' ]; then
+        # Always try to reinstall deps when not in prod
         composer install --prefer-dist --no-progress --no-suggest --no-interaction
     fi
 

--- a/docker/httpd/httpd.conf
+++ b/docker/httpd/httpd.conf
@@ -1,0 +1,27 @@
+ServerName localhost
+Listen 443
+
+SSLEngine on
+SSLCertificateFile "/usr/local/apache2/conf/server.crt"
+SSLCertificateKeyFile "/usr/local/apache2/conf/server.key"
+SSLSessionCache "shmcb:/usr/local/apache2/logs/ssl_scache(512000)"
+
+User daemon
+Group daemon
+
+ErrorLog /proc/self/fd/2
+CustomLog /proc/self/fd/1 "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\""
+
+Protocols h2 http/1.1
+
+ProxyPass / http://nginx/
+ProxyPassReverse / http://nginx/
+
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule http2_module modules/mod_http2.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_http_module modules/mod_proxy_http.so
+LoadModule socache_shmcb_module modules/mod_socache_shmcb.so
+LoadModule ssl_module modules/mod_ssl.so
+LoadModule unixd_module modules/mod_unixd.so


### PR DESCRIPTION
Just open `https://localhost`.

* The HTTP/2 reverse proxy **is not secure** and is not suited for production usage. Prefer using CloudFlare or the reverse proxy provided by your cloud platform in production.
* Apache is used instead of Nginx as reverse proxy because Nginx doesn't support HTTP/2 Push yet bot Apache does (and this feature is present in Symfony: WebLink component)