### PR TITLE
Use php:7.2-fpm-alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM composer:1.5
-FROM php:7.1-fpm-alpine
+FROM php:7.2-fpm-alpine
 
 RUN apk add --no-cache --virtual .persistent-deps \
 		git \


### PR DESCRIPTION
This allows FPM to listen on all interfaces even when IPv6 is disabled so that instead of seeing this:-

```
ERROR: failed to create new listening socket: socket(): Address family not supported by protocol (97)
ERROR: FPM initialization failed
```

one should see this:-

```
NOTICE: Failed implicitly binding to ::, retrying with 0.0.0.0
NOTICE: fpm is running, pid 1
NOTICE: ready to handle connections
```

See https://github.com/docker-library/php/pull/562