### PR TITLE
Use SYMFONY_VERSION as a variable name everywhere to avoid mistakes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,10 @@ ARG STABILITY=stable
 ENV STABILITY ${STABILITY}
 
 # Allow to select skeleton version
-ARG VERSION=""
+ARG SYMFONY_VERSION=""
 
 # Download the Symfony skeleton and leverage Docker cache layers
-RUN composer create-project "symfony/skeleton ${VERSION}" . --stability=$STABILITY --prefer-dist --no-dev --no-progress --no-scripts --no-plugins --no-interaction
+RUN composer create-project "symfony/skeleton ${SYMFONY_VERSION}" . --stability=$STABILITY --prefer-dist --no-dev --no-progress --no-scripts --no-plugins --no-interaction
 
 ###> recipes ###
 ###< recipes ###

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       args:
-        VERSION: ${SYMFONY_VERSION}
+        SYMFONY_VERSION: ${SYMFONY_VERSION}
         STABILITY: stable
     volumes:
       # Comment out the next line in production
@@ -15,6 +15,8 @@ services:
       - /srv/app/var/cache/
       - /srv/app/var/logs/
       - /srv/app/var/sessions/
+    environment:
+      - SYMFONY_VERSION
 
   nginx:
     build:

--- a/docker/app/docker-entrypoint.sh
+++ b/docker/app/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
     # The first time volumes are mounted, the project needs to be recreated
     if [ ! -f composer.json ]; then
-        composer create-project "symfony/skeleton $VERSION" tmp --stability=$STABILITY --prefer-dist --no-progress --no-interaction
+        composer create-project "symfony/skeleton $SYMFONY_VERSION" tmp --stability=$STABILITY --prefer-dist --no-progress --no-interaction
         cp -Rp tmp/. .
         rm -Rf tmp/
     elif [ "$APP_ENV" != 'prod' ]; then


### PR DESCRIPTION
We missed one thing durring #11 review - value of env variable was not passed to container, so entrypoint ignored `SYMFONY_VERSION` and installed wrong (newest) version. I also renamed `VERSION` to `SYMFONY_VERSION` everywhere because this is confusing - `VERSION` was only valid for dockerfile, not for entrypoint script.

Tested this manually and looks fine. Previously I used `docker-compose up -d` and logs telling that it doesn't work were hidden.