### PR TITLE
Improve OPcache settings

### DIFF
--- a/docker/app/php.ini
+++ b/docker/app/php.ini
@@ -4,6 +4,8 @@ session.auto_start = Off
 short_open_tag = Off
 
 # http://symfony.com/doc/current/performance.html
+opcache.interned_strings_buffer = 16
 opcache.max_accelerated_files = 20000
+opcache.memory_consumption = 256
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600


### PR DESCRIPTION
`opcache.memory_consumption` is present on the [Symfony documentation](http://symfony.com/doc/current/performance.html#configure-opcache-for-maximum-performance) while `opcache.interned_strings_buffer` should be upgraded also as the default value is quite low.