### PR TITLE
Simplify docker-compose command with override file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ services:
 Then run:
 
 ````bash
-docker-compose -f docker-compose.yaml -f docker-compose.override.yaml up -d
+docker-compose up -d
 ````
+
+If `docker-compose.yaml` and a `docker-compose.override.yaml` are present on the same directory level, Docker Compose combines the two files into a single configuration, applying the configuration in the `docker-compose.override.yaml` file over and in addition to the values in the `docker-compose.yaml` file.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Docker compose automatically merge both `docker-compose.yaml` and `docker-compose.override.yaml` files if `-f`` is not provided.

So I simplified the command and make a quick note inspired from docker compose documentation (https://docs.docker.com/compose/reference/overview/#specifying-multiple-compose-files)