### PR TITLE
Add information to run behind a corporate proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,10 @@ RUN apk add --no-cache --virtual .persistent-deps \
 		zlib
 
 ENV APCU_VERSION 5.1.12
+
+### Uncomment to set your proxy for pear
+# RUN pear config-set http_proxy yourproxy
+
 RUN set -eux \
 	&& apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \

--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ For instance, use the following command to use the `master` branch of Symfony:
 STABILITY=dev docker-compose up --build
 ```
 
+## Build and running behind a proxy
+
+1. Uncomment in the Dockerfile the following line
+```bash
+RUN pear config-set http_proxy yourproxy
+```
+2. Replace "yourproxy" by your proxy
+3. Build
+```bash
+docker-compose build --build-arg http_proxy="yourproxy" --build-arg https_proxy="yourproxy"
+```
+4. Up
+```bash
+docker-compose up
+```
+
 ## Debugging
 
 The default Docker stack is shipped without a Xdebug stage.


### PR DESCRIPTION
Even if it's not a bug and it's more related about general proxy knowledge (in and outside Docker), I think it's always good to add some information if someone (like me) wanted to run it behind a corporate proxy.
