### PR TITLE
Fix --with-libzip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN set -eux; \
 	    zlib-dev \
 	; \
 	\
-	docker-php-ext-configure zip --with-libzip; \
+	docker-php-ext-configure zip; \
 	docker-php-ext-install -j$(nproc) \
 	    intl \
 	    zip \


### PR DESCRIPTION
--with-libzip was removed with PHP 7.4 and I don't know why the build on the initial PR was green