### PR TITLE
Remove global Flex as it's not needed anymore with Composer 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,10 +66,7 @@ RUN set -eux; \
 
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
-# install Symfony Flex globally to speed up download of Composer packages (parallelized prefetching)
-RUN set -eux; \
-	composer global require "symfony/flex" --prefer-dist --no-progress --classmap-authoritative; \
-	composer clear-cache
+
 ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
 WORKDIR /srv/app


### PR DESCRIPTION
As the Docker image is now using Composer 2, this trick is not needed anymore.
