### PR TITLE
fix: experimental_http3 moved under servers.protocol

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,5 +1,9 @@
 {
-    experimental_http3
+    servers {
+        protocol {
+            experimental_http3
+        }
+    }
 }
 
 {$SERVER_NAME}


### PR DESCRIPTION
fix `experimental_http3` deprecation (moved under `server.protocol` "namespace")
