### PR TITLE
fix: do not check DB availability if code errors

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -32,14 +32,20 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	if grep -q ^DATABASE_URL= .env; then
 		echo "Waiting for db to be ready..."
 		ATTEMPTS_LEFT_TO_REACH_DATABASE=60
-		until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || bin/console doctrine:query:sql "SELECT 1" >/dev/null 2>&1; do
+		until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || DATABASE_ERROR=$(bin/console doctrine:query:sql "SELECT 1" 2>&1); do
+			if [ $? -eq 255 ]; then
+				# If the doctrine commands exits with 255, another (unrecoverable) error occurred, and we stop retrying
+				ATTEMPTS_LEFT_TO_REACH_DATABASE=0
+				break
+			fi
 			sleep 1
 			ATTEMPTS_LEFT_TO_REACH_DATABASE=$((ATTEMPTS_LEFT_TO_REACH_DATABASE - 1))
 			echo "Still waiting for db to be ready... Or maybe the db is not reachable. $ATTEMPTS_LEFT_TO_REACH_DATABASE attempts left"
 		done
 
 		if [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ]; then
-			echo "The db is not up or not reachable"
+			echo "The database is not up or not reachable:"
+			echo "$DATABASE_ERROR"
 			exit 1
 		else
 			echo "The db is now ready and reachable"

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -34,7 +34,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		ATTEMPTS_LEFT_TO_REACH_DATABASE=60
 		until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || DATABASE_ERROR=$(bin/console doctrine:query:sql "SELECT 1" 2>&1); do
 			if [ $? -eq 255 ]; then
-				# If the doctrine commands exits with 255, another (unrecoverable) error occurred, and we stop retrying
+				# If the Doctrine command exits with 255, an unrecoverable error occurred
 				ATTEMPTS_LEFT_TO_REACH_DATABASE=0
 				break
 			fi


### PR DESCRIPTION
Do not wait for the DB to be available if there are other errors blocking the access to it.

How to test it: 
- Create an application with a DB
- Add a PHP error in our files (controller, commands, ....)
- Restart the php container