### PR TITLE
fix: Caddy error message servers

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -2,7 +2,7 @@
     # Debug
     {$DEBUG}
     # HTTP/3 support
-    servers {
+    servers :443 {
         protocol {
             experimental_http3
         }


### PR DESCRIPTION
fix: error message : run: adapting config using caddyfile: /etc/caddy/Caddyfile:5: unrecognized global option: servers

https://caddyserver.com/docs/caddyfile/options