### PR TITLE
feat: create database at startup

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -30,6 +30,8 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	fi
 
 	if grep -q ^DATABASE_URL= .env; then
+		echo "Try to create database"
+		bin/console doctrine:database:create --if-not-exists --no-interaction
 		echo "Waiting for db to be ready..."
 		ATTEMPTS_LEFT_TO_REACH_DATABASE=60
 		until [ $ATTEMPTS_LEFT_TO_REACH_DATABASE -eq 0 ] || DATABASE_ERROR=$(bin/console doctrine:query:sql "SELECT 1" 2>&1); do


### PR DESCRIPTION
feat: Try to create empty database at startup, in order to avoid the error message : "The database is not up or not reachable" if database doesnt exist.