### PR TITLE
Fix comment and add another comment

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,10 +4,12 @@ version: "3.4"
 services:
   php:
     volumes:
+      # The "cached" option has no effect on Linux but improves performance on Mac
       - ./:/srv/app:rw,cached
       - ./docker/php/conf.d/symfony.dev.ini:/usr/local/etc/php/conf.d/symfony.ini
-      # If you develop on Linux, comment out the following volumes to just use bind-mounted project directory from host
-      # - ./var:/srv/app/var:rw
+      # If you develop on Mac you can remove the var/ directory from the bind-mount
+      # for better performance by enabling the next line 
+      # - /srv/app/var
     environment:
       APP_ENV: dev
 


### PR DESCRIPTION
This comment seems to got wrong over time:

The config made sense first: https://github.com/dunglas/symfony-docker/commit/df6286b2e91213100ff36dae25c8fac6384ef804#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3

Then the config became obsolete: https://github.com/dunglas/symfony-docker/commit/4e258087dc131307e84f95a5020db553259eb063

Then the config became a (I think wrong) comment: https://github.com/dunglas/symfony-docker/commit/0167334910d6f7c56c9dc9d68c9773dd35207ef3#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3

I don't use Mac so I don't know but maybe the whole comment could be removed completely since the `cached` option was introduced.