### PR TITLE
docs: remove Messenger from the list of supported packages

### DIFF
--- a/docs/extra-services.md
+++ b/docs/extra-services.md
@@ -7,4 +7,3 @@ The currently supported packages are:
 
 * `symfony/orm-pack`: install a PostgreSQL service
 * `symfony/mercure-bundle`: use the Mercure.rocks module shipped with Caddy
-* `symfony/messenger`: install a RabbitMQ service


### PR DESCRIPTION
Fixes #147. Messenger now uses Postgres by default through Doctrine, which is also supported by symfony-docker.