### PR TITLE
fix: prevent installing another Mercure hub

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -17,3 +17,6 @@ services:
     volumes:
       - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
       - ./public:/srv/app/public:ro
+
+###> symfony/mercure-bundle ###
+###< symfony/mercure-bundle ###

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,13 @@ services:
         published: 443
         protocol: udp
 
+# Mercure is installed as a Caddy module, prevent the Flex recipe from installing another service
+###> symfony/mercure-bundle ###
+###< symfony/mercure-bundle ###
+
 volumes:
   php_socket:
   caddy_data:
   caddy_config:
+###> symfony/mercure-bundle ###
+###< symfony/mercure-bundle ###


### PR DESCRIPTION
Prevent the installation of https://github.com/symfony/recipes/pull/1007 because it's not needed in our case.