### PR TITLE
Fix: Do not run composer install in prod

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -26,11 +26,12 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		cd -
 
 		rm -Rf tmp/
-	elif [ "$APP_ENV" != 'prod' ]; then
-		rm -f .env.local.php
 	fi
 
-	composer install --prefer-dist --no-progress --no-interaction
+	if [ "$APP_ENV" != 'prod' ]; then
+		rm -f .env.local.php
+		composer install --prefer-dist --no-progress --no-interaction
+	fi
 
 	if grep -q ^DATABASE_URL= .env; then
 		if [ "$CREATION" = "1" ]; then


### PR DESCRIPTION
IMHO always running composer install in PHP entrypoint is wrong.
In production this will:
* Install also dev dependencies which should not be installed
* Slow the starting phase of the container and this in turns increase the deployment downtime

So assume that in production the container runs from the image built with the Dockerfile, run composer install in entrypoint is wrong.