### PR TITLE
Sync Docker and composer PHP versions in new projects

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -21,7 +21,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		composer create-project "$SKELETON $SYMFONY_VERSION" tmp --stability="$STABILITY" --prefer-dist --no-progress --no-interaction --no-install
 
 		cd tmp
-		composer require "php:$PHP_VERSION"
+		composer require "php:>=$PHP_VERSION"
 		composer config --json extra.symfony.docker 'true'
 		cp -Rp . ..
 		cd -

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -21,6 +21,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		composer create-project "$SKELETON $SYMFONY_VERSION" tmp --stability="$STABILITY" --prefer-dist --no-progress --no-interaction --no-install
 
 		cd tmp
+		composer require "php:$PHP_VERSION"
 		composer config --json extra.symfony.docker 'true'
 		cp -Rp . ..
 		cd -


### PR DESCRIPTION
At time of writing, if you clone and create a new project, the PHP container will use PHP 8.0, but the composer.json file will specify >=7.2.5, this makes them the same.