### PR TITLE
feat : remove deprecated flags

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -4,11 +4,10 @@ version: "3.4"
 services:
   php:
     volumes:
-      # The "cached" option has no effect on Linux but improves performance on Mac
-      - ./:/srv/app:rw,cached
+      - ./:/srv/app
       - ./docker/php/conf.d/symfony.dev.ini:/usr/local/etc/php/conf.d/symfony.ini
       # If you develop on Mac you can remove the var/ directory from the bind-mount
-      # for better performance by enabling the next line 
+      # for better performance by enabling the next line
       # - /srv/app/var
     environment:
       APP_ENV: dev


### PR DESCRIPTION
Flags like :delegated, :cached and :ro don't exist anymore

See https://github.com/docker/for-mac/issues/5402 