### PR TITLE
fix: alpine 3.16 support for `ext-intl`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ ARG APCU_VERSION=5.1.21
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		icu-data-full \
 		icu-dev \
 		libzip-dev \
 		zlib-dev \


### PR DESCRIPTION
The latest official php images [are now based on Alpine 3.16](https://hub.docker.com/_/php?tab=tags&page=1&name=8.1-fpm-alpine), which ships with ICU 71.1 (vs 69.1 in Alpine 3.15).

This breaks date & currency formatting, since only english locale is now included by default.

> _The ICU data [has been split](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.16.0#ICU_data_split) into [icu-data-en](https://pkgs.alpinelinux.org/packages?name=icu-data-en) (default) and [icu-data-full](https://pkgs.alpinelinux.org/packages?name=icu-data-full) packages. Users may need to install icu-data-full for non-English locales or legacy charset converters support._

[(source)](https://alpinelinux.org/posts/Alpine-3.16.0-released.html)