### PR TITLE
Replace unsupported wip tld by localhost

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -28,7 +28,7 @@ For instance, use the following command to use the `master` branch of Symfony:
 
 Use the `SERVER_NAME` environment variable to define your custom server name(s).
 
-    SERVER_NAME="symfony.wip, caddy:80" docker-compose up --build
+    SERVER_NAME="symfony.localhost, caddy:80" docker-compose up --build
 
 If you use Mercure, keep `caddy:80` in the list to allow the PHP container to request the caddy service.
 


### PR DESCRIPTION
Because
```
symfony-docker-caddy-1  | {"level":"error","ts":1655149969.4670324,"logger":"tls.obtain","msg":"could not get certificate from issuer","identifier":"symfony.wip","issuer":"acme.zerossl.com-v2-DV90","error":"HTTP 400 urn:ietf:params:acme:error:rejectedIdentifier - Invalid DNS identifier [symfony.wip]"}
symfony-docker-caddy-1  | {"level":"error","ts":1655150030.459003,"logger":"tls.obtain","msg":"could not get certificate from issuer","identifier":"symfony.wip","issuer":"acme-v02.api.letsencrypt.org-directory","error":"HTTP 400 urn:ietf:params:acme:error:rejectedIdentifier - Error creating new order :: Cannot issue for \"symfony.wip\": Domain name does not end with a valid public suffix (TLD)"}
symfony-docker-caddy-1  | {"level":"error","ts":1655150039.532795,"logger":"tls.obtain","msg":"could not get certificate from issuer","identifier":"symfony.wip","issuer":"acme.zerossl.com-v2-DV90","error":"HTTP 400 urn:ietf:params:acme:error:rejectedIdentifier - Invalid DNS identifier [symfony.wip]"}
```