### PR TITLE
docs: trust certificate on Windows

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,6 +12,8 @@ If you have a TLS trust issues, you can copy the self-signed certificate from Ca
     $ docker cp $(docker compose ps -q caddy):/data/caddy/pki/authorities/local/root.crt /tmp/root.crt && sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain /tmp/root.crt
     # Linux
     $ docker cp $(docker compose ps -q caddy):/data/caddy/pki/authorities/local/root.crt /usr/local/share/ca-certificates/root.crt && sudo update-ca-certificates
+    # Windows
+    $ docker compose cp caddy:/data/caddy/pki/authorities/local/root.crt %TEMP%/root.crt && certutil -addstore -f "ROOT" %TEMP%/root.crt
 
 ## HTTPs and Redirects
 


### PR DESCRIPTION
Added information about how to add the caddy cert to the trusted certificates on Windows as this info was only provided for Linux & Mac.

_Note:_ I'm not using the same "docker cp $(docker compose ps -q caddy)" syntax as this does not work in the standard command prompt on Windows and as far as I know there is no equivalent. 