### PR TITLE
fix: stop use obsolete experimental_http3 option

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,12 +1,6 @@
 {
     # Debug
     {$DEBUG}
-    # HTTP/3 support
-    servers {
-        protocol {
-            experimental_http3
-        }
-    }
 }
 
 {$SERVER_NAME}


### PR DESCRIPTION
> Caddy now enables [RFC 9114](https://datatracker.ietf.org/doc/rfc9114/)-compliant HTTP/3 by default. The experimental_http3 option has graduated and been removed.

https://github.com/caddyserver/caddy/releases/tag/v2.6.0
