### PR TITLE
docker: added missing xsl extension... or doc ?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN set -eux; \
     	zip \
     	apcu \
 		opcache \
+		xsl \
     ;
 
 ###> recipes ###

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -9,7 +9,7 @@ services:
       - ./:/srv/app
       - ./docker/php/conf.d/app.dev.ini:/usr/local/etc/php/conf.d/app.dev.ini:ro
       # If you develop on Mac or Windows you can remove the vendor/ directory
-      #  from the bind-mount for better performance by enabling the next line:
+      # from the bind-mount for better performance by enabling the next line:
       #- /srv/app/vendor
     environment:
       # See https://xdebug.org/docs/all_settings#mode 

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -11,10 +11,10 @@ For example, in the [getting started section](/README.md#getting-started), the
 2. Run `make up` (detached mode without logs)
 3. Run `make down` to stop the Docker containers
 
-Of course, this template is basic for now. But, as your application is growing,
-you will probably want to add some targets like running your tests as described
+Of course, this template is basic for now. But, as your application grows,
+you will probably want to add some targets, like running your tests as described
 in [the Symfony book](https://symfony.com/doc/current/the-fast-track/en/17-tests.html#automating-your-workflow-with-a-makefile).
-You can also find a more complete example in this [snippet](https://www.strangebuzz.com/en/snippets/the-perfect-makefile-for-symfony).
+You can also find a complete example in this [snippet](https://www.strangebuzz.com/en/snippets/the-perfect-makefile-for-symfony).
 
 If you want to run make from within the `php` container, in the [Dockerfile](/Dockerfile),
 add:


### PR DESCRIPTION
Hello, when installing `symfony/mailer`and when linting Twig files, you have an error because some Twig filters are missing.

```
ERROR  in /srv/app/vendor/symfony/twig-bridge/Resources/views/Email/zurb_2/notification/body.html.twig (line -1)
  >> The "inline_css" filter is part of the CssInlinerExtension, which is not installed/enabled; try running "composer require twig/cssinliner-extra".
```

When installing the required Twig extensions, the xsl php extension is required: 


```
composer require twig/inky-extra
Using version ^3.4 for twig/inky-extra
./composer.json has been updated
Running composer update twig/inky-extra
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - lorenzo/pinky[1.0.5, ..., 1.0.7] require ext-xsl * -> it is missing from your system. Install or enable PHP's xsl extension.
    - twig/inky-extra v3.4.0 requires lorenzo/pinky ^1.0.5 -> satisfiable by lorenzo/pinky[1.0.5, 1.0.6, 1.0.7].
    - Root composer.json requires twig/inky-extra ^3.4 -> satisfiable by twig/inky-extra[v3.4.0].
```

Or we can just modify the doc, that the xsl extension should be added when using this extra service ?  

