### PR TITLE
chore: disable Caddy's push directive

### DIFF
--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -26,7 +26,6 @@ route {
         {$MERCURE_EXTRA_DIRECTIVES}
     }
     vulcain
-    push
     php_fastcgi unix//var/run/php/php-fpm.sock
     encode zstd gzip
     file_server


### PR DESCRIPTION
Server Push has been removed from Chrome and this Caddy directive is known to cause issues in some cases (it has already been removed from API Platform).