### PR TITLE
Use native caddy healthcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,6 @@ jobs:
               run: curl http://localhost
             - name: Check HTTPS reachability
               run: curl -k https://localhost
+            - name: Log
+              if: always()
+              run: docker-compose logs

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -26,7 +26,11 @@ route {
         {$MERCURE_EXTRA_DIRECTIVES}
     }
     vulcain
-    php_fastcgi unix//var/run/php/php-fpm.sock
+    php_fastcgi unix//var/run/php/php-fpm.sock {
+        health_uri /ping
+        health_interval 1s
+        lb_try_duration 5s
+    }
     encode zstd gzip
     file_server
 }

--- a/docker/php/php-fpm.d/zz-docker.conf
+++ b/docker/php/php-fpm.d/zz-docker.conf
@@ -6,3 +6,4 @@ process_control_timeout = 20
 listen = /var/run/php/php-fpm.sock
 listen.mode = 0666
 ping.path = /ping
+access.suppress_path[] = /ping


### PR DESCRIPTION
Resolves https://github.com/dunglas/symfony-docker/issues/377

```
caddy_1  | {"level":"info","ts":1677492269.4432561,"logger":"http.handlers.reverse_proxy.health_checker.active","msg":"HTTP request failed","host":"localhost","error":"Get \"http://localhost/ping\": dialing backend: dial unix /var/run/php/php-fpm.sock: connect: no such file or directory"}
php_1    | Executing script assets:install public [OK]
php_1    | [27-Feb-2023 10:04:29] NOTICE: fpm is running, pid 1
php_1    | [27-Feb-2023 10:04:29] NOTICE: ready to handle connections
caddy_1  | {"level":"info","ts":1677492270.444267,"logger":"http.handlers.reverse_proxy.health_checker.active","msg":"host is up","host":"localhost"}
```