### PR TITLE
Format dev PHP extensions as prod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,9 @@ RUN rm "$PHP_INI_DIR/conf.d/app.prod.ini"; \
 COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/
 
 RUN set -eux; \
-	install-php-extensions xdebug
+	install-php-extensions \
+    	xdebug \
+    ;
 
 RUN rm -f .env.local.php
 


### PR DESCRIPTION
Formatted dev PHP extensions list to keep same code style with prod one.

Found it useful when added new extension to the list:

```Dockerfile
RUN set -eux; \
	install-php-extensions \
    	xdebug \
    	xhprof \
    ;