### PR TITLE
Fix indentation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,10 @@ RUN apk add --no-cache \
 
 RUN set -eux; \
     install-php-extensions \
-    	apcu \
-    	intl \
+		apcu \
+		intl \
 		opcache \
-    	zip \
+		zip \
     ;
 
 ###> recipes ###


### PR DESCRIPTION
There was an indentation with 4spaces that made vim edition look weird.