### PR TITLE
feat: suppress Docker healthcheck requests from logs

### DIFF
--- a/docker/php/php-fpm.d/zz-docker.conf
+++ b/docker/php/php-fpm.d/zz-docker.conf
@@ -6,3 +6,4 @@ process_control_timeout = 20
 listen = /var/run/php/php-fpm.sock
 listen.mode = 0666
 ping.path = /ping
+access.suppress_path[] = /ping


### PR DESCRIPTION
Backport of https://github.com/api-platform/api-platform/pull/2404, from @beerfranz.
Relies on the feature introduced in https://github.com/php/php-src/commit/327bb219867b16e1161da632fba170f46692484b.