### PR TITLE
Add test command to healthcheck in docker-compose.yml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,8 @@ VOLUME /srv/app/var/
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 RUN set -eux; \
-	install-php-extensions \
-    	xdebug \
+    install-php-extensions \
+		xdebug \
     ;
 
 COPY --link docker/php/conf.d/app.dev.ini $PHP_INI_DIR/conf.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - php_socket:/var/run/php
     healthcheck:
+      test: ["CMD", "docker-healthcheck"]
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
According to Compose docs, the `healthcheck` instruction should specify a `test` command in `docker-compose.yml`.

See: https://docs.docker.com/compose/compose-file/compose-file-v3/#healthcheck

PS: Also formatting some spaces to match the rest of the `Dockerfile`.