### PR TITLE
chore: remove useless fgci package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ WORKDIR /app
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
 		acl \
-		fcgi \
 		file \
 		gettext \
 		git \


### PR DESCRIPTION
Not needed now that we use FrankenPHP.