### PR TITLE
Update makefile template

### DIFF
--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -47,7 +47,7 @@ SYMFONY  = $(PHP) bin/console
 
 # Misc
 .DEFAULT_GOAL = help
-.PHONY        : help build up start down logs sh composer vendor sf cc
+.PHONY        : help build up start down logs sh composer vendor sf cc test
 
 ## —— 🎵 🐳 The Symfony Docker Makefile 🐳 🎵 ——————————————————————————————————
 help: ## Outputs this help screen
@@ -70,6 +70,11 @@ logs: ## Show live logs
 
 sh: ## Connect to the FrankenPHP container
 	@$(PHP_CONT) sh
+
+test: ## Start tests with phpunit, pass the parameter "c=" to add options to phpunit, example: make test c="--group e2e --stop-on-failure"
+	@$(eval c ?=)
+	@$(DOCKER_COMP) exec -e APP_ENV=test php bin/phpunit $(c)
+
 
 ## —— Composer 🧙 ——————————————————————————————————————————————————————————————
 composer: ## Run composer, pass the parameter "c=" to run a given command, example: make composer c='req symfony/orm-pack'

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -68,7 +68,7 @@ down: ## Stop the docker hub
 logs: ## Show live logs
 	@$(DOCKER_COMP) logs --tail=0 --follow
 
-sh: ## Connect to the PHP FPM container
+sh: ## Connect to the FrankenPHP container
 	@$(PHP_CONT) sh
 
 ## —— Composer 🧙 ——————————————————————————————————————————————————————————————


### PR DESCRIPTION
I've added the `test` target in the makefile template in order to remember to add the `APP_ENV=test` before the `phpunit` command.
I'm not sure to use the correct letter : `c` for adding options to `phpunit` : 
- pros : the same letter is used for `composer` and `sf` targets
- cons : `o` would be more appropriate since it passes options to `phpunit` and not command