### PR TITLE
fix: install Composer dependencies if vendor directory is empty

### DIFF
--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		fi
 	fi
 
-	if [ -z "$(ls -A 'vendor/')" ]; then
+	if [ -z "$(ls -A 'vendor/' 2>/dev/null)" ]; then
 		composer install --prefer-dist --no-progress --no-interaction
 	fi
 

--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		fi
 	fi
 
-	if [ ! -d 'vendor/' ]; then
+	if [ -z "$(ls -A 'vendor/')" ]; then
 		composer install --prefer-dist --no-progress --no-interaction
 	fi
 


### PR DESCRIPTION
Fixes #490 