### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ with [FrankenPHP](https://frankenphp.dev) and [Caddy](https://caddyserver.com/) 
 
 1. If not already done, [install Docker Compose](https://docs.docker.com/compose/install/) (v2.10+)
 2. Run `docker compose build --no-cache` to build fresh images
-3. Run `docker compose up --pull -d --wait` to start the project
+3. Run `docker compose up --pull always -d --wait` to start the project
 4. Open `https://localhost` in your favorite web browser and [accept the auto-generated TLS certificate](https://stackoverflow.com/a/15076602/1352334)
 5. Run `docker compose down --remove-orphans` to stop the Docker containers.
 


### PR DESCRIPTION
On Mac OS with Docker Compose version v2.23.0-desktop.1

```
❯ docker compose up --pull -d --wait
invalid --pull option "-d"
```

According the documentation, --pull option requires an argument ("always"|"missing"|"never")

Thanks for your review !
