### PR TITLE
docs(production): fix command to run containers

### DIFF
--- a/docs/extra-services.md
+++ b/docs/extra-services.md
@@ -1,7 +1,7 @@
 # Support for Extra Services
 
 Symfony Docker is extensible. When you install a compatible Composer package using Symfony Flex,
-the recipe will automatically modify the `Dockerfile` and `docker-compose.yml` to fulfill the requirements of this package.
+the recipe will automatically modify the `Dockerfile` and `compose.yaml` to fulfill the requirements of this package.
 
 The currently supported packages are:
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -61,7 +61,7 @@ Go into the directory containing your project (`<project-name>`), and start the 
 SERVER_NAME=your-domain-name.example.com \
 APP_SECRET=ChangeMe \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --wait
+docker compose -f compose.yaml -f compose.prod.yaml up -d --wait
 ```
 
 Be sure to replace `your-domain-name.example.com` by your actual domain name and to set the values of `APP_SECRET`, `CADDY_MERCURE_JWT_SECRET` to cryptographically secure random values.
@@ -77,7 +77,7 @@ Alternatively, if you don't want to expose an HTTPS server but only an HTTP one,
 SERVER_NAME=:80 \
 APP_SECRET=ChangeMe \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
-docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --wait
+docker compose -f compose.yaml -f compose.prod.yaml up -d --wait
 ```
 
 ## Deploying on Multiple Nodes

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -26,7 +26,7 @@ For instance, to use self-signed certificates created with [mkcert](https://gith
    `mkdir frankenphp/certs -p`
 3. Generate the certificates for your local host (example: "server-name.localhost"):
    `mkcert -cert-file frankenphp/certs/tls.pem -key-file frankenphp/certs/tls.key "server-name.localhost"`
-4. Add these lines to the `./docker-compose.override.yml` file about `CADDY_EXTRA_CONFIG` environment and volume for the `php` service :
+4. Add these lines to the `./compose.override.yaml` file about `CADDY_EXTRA_CONFIG` environment and volume for the `php` service :
     ```diff
     php:
       environment:


### PR DESCRIPTION
The commands were pointing to a `docker-compose.yml` file that doesn't exist. It's `compose.yaml` now.