### PR TITLE
Introduce TRUSTED_HOSTS and CADDY_MERCURE_PUBLIC_URL variables

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -7,12 +7,12 @@ services:
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16}
-      TRUSTED_HOSTS: ^${SERVER_NAME:-example\.com|localhost}|php$$
+      TRUSTED_HOSTS: ${TRUSTED_HOSTS:-^${SERVER_NAME:-example\.com|localhost}|php$$}
       # Run "composer require symfony/orm-pack" to install and configure Doctrine ORM
       DATABASE_URL: postgresql://${POSTGRES_USER:-app}:${POSTGRES_PASSWORD:-!ChangeMe!}@database:5432/${POSTGRES_DB:-app}?serverVersion=${POSTGRES_VERSION:-15}&charset=${POSTGRES_CHARSET:-utf8}
       # Run "composer require symfony/mercure-bundle" to install and configure the Mercure integration
       MERCURE_URL: ${CADDY_MERCURE_URL:-http://php/.well-known/mercure}
-      MERCURE_PUBLIC_URL: https://${SERVER_NAME:-localhost}/.well-known/mercure
+      MERCURE_PUBLIC_URL: ${CADDY_MERCURE_PUBLIC_URL:-https://${SERVER_NAME:-localhost}/.well-known/mercure}
       MERCURE_JWT_SECRET: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       # The two next lines can be removed after initial installation
       SYMFONY_VERSION: ${SYMFONY_VERSION:-}

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -22,7 +22,7 @@ But sometimes you may prefer using custom certificates.
 For instance, to use self-signed certificates created with [mkcert](https://github.com/FiloSottile/mkcert) do as follows:
 
 1. Locally install `mkcert`
-2. Create the folder storing the certs: 
+2. Create the folder storing the certs:
    `mkdir frankenphp/certs -p`
 3. Generate the certificates for your local host (example: "server-name.localhost"):
    `mkcert -cert-file frankenphp/certs/tls.pem -key-file frankenphp/certs/tls.key "server-name.localhost"`
@@ -37,3 +37,16 @@ For instance, to use self-signed certificates created with [mkcert](https://gith
         - ./public:/app/public:ro
     ```
 5. Restart your `php` service
+
+## Disabling HTTPS for Local Development
+
+To disable HTTPS, configure your environment to use HTTP by setting the following variables and starting the project with this command:
+
+```bash
+SERVER_NAME=http://localhost \
+MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
+TRUSTED_HOSTS='^localhost|php$' \
+docker compose up --pull always -d --wait
+```
+
+Ensure your application is accessible over HTTP by visiting `http://localhost` in your web browser.


### PR DESCRIPTION
Fix issue with invalid `TRUSTED_HOSTS` and `MERCURE_PUBLIC_URL` when using `http://localhost` or `:80` as `SERVER_NAME` value

Follow up of https://github.com/api-platform/api-platform/pull/2666

Should I add a note in the docs @dunglas?