### PR TITLE
Added Git specific instuctions for copying the files to an existing project

### DIFF
--- a/docs/existing-project.md
+++ b/docs/existing-project.md
@@ -2,9 +2,13 @@
 
 It's also possible to use Symfony Docker with existing projects!
 
-First, [download this skeleton](https://github.com/dunglas/symfony-docker). If you clone the Git repository, be sure to remove the `.git` directory to prevent conflicts with the `.git` directory already in your existing project.
+First, [download this skeleton](https://github.com/dunglas/symfony-docker).
 
-Then, copy the Docker-related files from the skeleton to your existing project:
+If you cloned the Git repository you can copy the files from the repository using git and tar:
+
+    git archive --format=tar HEAD | tar -xC my-existing-project/
+
+If you downloaded the skeleton with zip you can just copy the extracted files:
 
     cp -Rp symfony-docker/. my-existing-project/
 

--- a/docs/existing-project.md
+++ b/docs/existing-project.md
@@ -4,7 +4,8 @@ It's also possible to use Symfony Docker with existing projects!
 
 First, [download this skeleton](https://github.com/dunglas/symfony-docker).
 
-If you cloned the Git repository you can copy the files from the repository using git and tar:
+If you cloned the Git repository, be sure to not copy the `.git` directory to prevent conflicts with the `.git` directory already in your existing project.
+You can copy the contents of the repository using git and tar. This will not contain `.git` or any uncommited changes.
 
     git archive --format=tar HEAD | tar -xC my-existing-project/
 

--- a/docs/existing-project.md
+++ b/docs/existing-project.md
@@ -9,7 +9,7 @@ You can copy the contents of the repository using git and tar. This will not con
 
     git archive --format=tar HEAD | tar -xC my-existing-project/
 
-If you downloaded the skeleton with zip you can just copy the extracted files:
+If you downloaded the skeleton as a zip you can just copy the extracted files:
 
     cp -Rp symfony-docker/. my-existing-project/
 


### PR DESCRIPTION
With the new instructions the copying to an existing project doesn't destroy the cloned symfony-docker repository.
