### PR TITLE
Update README with Symfony set up hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ with [FrankenPHP](https://frankenphp.dev) and [Caddy](https://caddyserver.com/) 
 4. Open `https://localhost` in your favorite web browser and [accept the auto-generated TLS certificate](https://stackoverflow.com/a/15076602/1352334)
 5. Run `docker compose down --remove-orphans` to stop the Docker containers.
 
+> **_NOTE:_**  `docker compose up --pull always -d --wait` will set up a Symfony Flex application. 
+
 ## Features
 
 * Production, development and CI ready

--- a/README.md
+++ b/README.md
@@ -9,11 +9,9 @@ with [FrankenPHP](https://frankenphp.dev) and [Caddy](https://caddyserver.com/) 
 
 1. If not already done, [install Docker Compose](https://docs.docker.com/compose/install/) (v2.10+)
 2. Run `docker compose build --no-cache` to build fresh images
-3. Run `docker compose up --pull always -d --wait` to start the project
+3. Run `docker compose up --pull always -d --wait` to set up and start a fresh Symfony project
 4. Open `https://localhost` in your favorite web browser and [accept the auto-generated TLS certificate](https://stackoverflow.com/a/15076602/1352334)
 5. Run `docker compose down --remove-orphans` to stop the Docker containers.
-
-> **_NOTE:_**  `docker compose up --pull always -d --wait` will set up a Symfony Flex application. 
 
 ## Features
 


### PR DESCRIPTION
Added a clarification note to README.md to inform users how to set up a Symfony Flex application using the `docker compose up --pull always -d --wait` Docker command. This additional information provides clearer guidance for users looking to set up the application.