### PR TITLE
fix starting container process caused: exec: "bin/phpunit": permission

### DIFF
--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -51,6 +51,10 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		if [ "$( find ./migrations -iname '*.php' -print -quit )" ]; then
 			php bin/console doctrine:migrations:migrate --no-interaction --all-or-nothing
 		fi
+		if [ "$APP_ENV" != 'prod' ]; then
+   			# https://github.com/api-platform/api-platform/issues/1819
+   			chmod +x bin/phpunit
+		fi
 	fi
 
 	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var


### PR DESCRIPTION
Hi,
While checking the CI template, I encountered an error: `OCI runtime exec failed: exec failed: container_linux.go:370: starting container process caused: exec: "bin/phpunit": permission.` It surprised me a lot because everything was working fine locally. I managed to find a solution to the problem here: https://github.com/api-platform/api-platform/issues/1819. I added a patch to the docker-entrypoint.sh file:

```shell
if [ "$APP_ENV" != 'prod' ]; then
   # https://github.com/api-platform/api-platform/issues/1819
   chmod +x bin/phpunit
fi
```
and everything started functioning correctly.