### PR TITLE
Update the documentation to change from PostgreSQL to MySQL.

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -21,6 +21,12 @@ Change the database image to use MySQL instead of PostgreSQL in `compose.yaml`:
 +     MYSQL_PASSWORD: ${MYSQL_PASSWORD:-!ChangeMe!}
 -     POSTGRES_USER: ${POSTGRES_USER:-app}
 +     MYSQL_USER: ${MYSQL_USER:-app}
+    healthcheck:
+-     test: ["CMD", "pg_isready", "-d", "${POSTGRES_DB:-app}", "-U", "${POSTGRES_USER:-app}"]
++     test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+      timeout: 5s
+      retries: 5
+      start_period: 60s
     volumes:
 -     - database_data:/var/lib/postgresql/data:rw
 +     - database_data:/var/lib/mysql:rw


### PR DESCRIPTION
The install of doctrine-bundle adds a healthcheck section that was not documented.
Of course, GitHub CI was failing with an unhealthy status because of the PostgreSQL command. 

Update the documentation on how to use MySQL.