### PR TITLE
Fix Docker development volumes location for the 20-app.dev.ini file

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -7,7 +7,7 @@ services:
     volumes:
       - ./:/app
       - ./frankenphp/Caddyfile:/etc/caddy/Caddyfile:ro
-      - ./frankenphp/conf.d/app.dev.ini:/usr/local/etc/php/conf.d/app.dev.ini:ro
+      - ./frankenphp/conf.d/20-app.dev.ini:/usr/local/etc/php/app.conf.d/20-app.dev.ini:ro
       # If you develop on Mac or Windows you can remove the vendor/ directory
       #  from the bind-mount for better performance by enabling the next line:
       #- /app/vendor


### PR DESCRIPTION
With the fix to load app's ini files after all other extensions are loaded (#617), the app-dev.ini file has been renamed 20-app.dev.ini and has been moved to a folder named "app.conf.d".

Although, the fix forgot to update the development environment file `compose.override.yaml` with the new name and location.