### PR TITLE
Install libnss3-tools so Caddy can use certutil for a root certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	file \
 	gettext \
 	git \
+    libnss3-tools \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \


### PR DESCRIPTION
Caddy is trying to install a root certificate but can't find certutil. This would help integrate certificates into the local trust store, which may be useful during local development.

The issue can be seen during the starting container:

     INFO    warning: "certutil" is not available, install "certutil" with "apt install libnss3-tools" or "yum install nss-tools" and try again

![image](https://github.com/user-attachments/assets/c4581e01-79f4-4516-9acc-aa97b8be7488)
