### PR TITLE
perf: improve FrankenPHP config

### DIFF
--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -19,7 +19,7 @@
 		}
 	}
 
-	root * /app/public
+	root /app/public
 	encode zstd br gzip
 
 	mercure {
@@ -44,5 +44,9 @@
 	# Disable Topics tracking if not enabled explicitly: https://github.com/jkarlin/topics
 	header ?Permissions-Policy "browsing-topics=()"
 
-	php_server
+	@phpRoute not file {path}
+	rewrite @phpRoute index.php
+	@frontController path index.php
+	php @frontController
+	file_server
 }


### PR DESCRIPTION
Expanded, the current config is similar to this:

```caddyfile
# Add trailing slash for directory requests
@canonicalPath {
	file {path}/index.php
	not path */
}
redir @canonicalPath {path}/ 308
# If the requested file does not exist, try index files
@indexFiles file {
	try_files {path} {path}/index.php index.php
	split_path .php
}
rewrite @indexFiles {http.matchers.file.relative}
# FrankenPHP!
@phpFiles path *.php
php @phpFiles
file_server
```

I recently took some time to profile and optimize FrankenPHP, and that config is the slowest part in FrankenPHP (this likely affects the `php_fastcgi` Caddy directive as well). All the calls to `try_files` and `file` do I/O operations, which are slow.
Most of these I/O operations are checks useful for traditional PHP apps where the document root contains a lot of `.php` files (like WordPress) but are not needed when using Symfony or Laravel.

This simplified config reduces the number of I/O to the strict minimum: just 1 check to see if the requested path exists on disk, and delegates to PHP if it's not the case.

In the future, I plan to add a `framework` subdirective to `php_server` that automatically generates this config.

cc @francislavoie, this may also be interesting for `php_fastcgi`.