### PR TITLE
feat: print message when docker-entrypoint finishes

### DIFF
--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -55,6 +55,8 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 
 	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
+
+	echo 'Entrypoint has finished its work !'
 fi
 
 exec docker-php-entrypoint "$@"

--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -56,7 +56,7 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
 
-	echo 'Entrypoint has finished its work !'
+	echo 'PHP app ready!'
 fi
 
 exec docker-php-entrypoint "$@"


### PR DESCRIPTION
**Problem statement :**
When running docker compose, for a few seconds / minutes, the container is running according to Docker, but in fact `docker-entrypoint.sh` is still downloading composer requirements and handling migrations. During this time, the app is not available. This means functionnal tests will fail if launched too early.

**Solution proposed :**
This pull requests aims to simply add a logging line at the end of `docker-enntrypoint.sh`, to provide a standard log that can be watched by dev / devops teams. A `grep` on docker logs will make people aware that : "ok, dependencies should be installed by now, so my app should be working".