### PR TITLE
feat: add build dir argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM dunglas/frankenphp:1-php8.3 AS frankenphp_upstream
 # https://docs.docker.com/compose/compose-file/#target
 
 
+ARG BUILD_DIR=.
 # Base FrankenPHP image
 FROM frankenphp_upstream AS frankenphp_base
 
@@ -41,9 +42,9 @@ ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
 ###> recipes ###
 ###< recipes ###
 
-COPY --link frankenphp/conf.d/10-app.ini $PHP_INI_DIR/app.conf.d/
-COPY --link --chmod=755 frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
-COPY --link frankenphp/Caddyfile /etc/caddy/Caddyfile
+COPY --link $BUILD_DIR/frankenphp/conf.d/10-app.ini $PHP_INI_DIR/app.conf.d/
+COPY --link --chmod=755 $BUILD_DIR/frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+COPY --link $BUILD_DIR/frankenphp/Caddyfile /etc/caddy/Caddyfile
 
 ENTRYPOINT ["docker-entrypoint"]
 
@@ -74,8 +75,8 @@ ENV FRANKENPHP_CONFIG="import worker.Caddyfile"
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
-COPY --link frankenphp/conf.d/20-app.prod.ini $PHP_INI_DIR/app.conf.d/
-COPY --link frankenphp/worker.Caddyfile /etc/caddy/worker.Caddyfile
+COPY --link $BUILD_DIR/frankenphp/conf.d/20-app.prod.ini $PHP_INI_DIR/app.conf.d/
+COPY --link $BUILD_DIR/frankenphp/worker.Caddyfile /etc/caddy/worker.Caddyfile
 
 # prevent the reinstallation of vendors at every changes in the source code
 COPY --link composer.* symfony.* ./
@@ -84,7 +85,7 @@ RUN set -eux; \
 
 # copy sources
 COPY --link . ./
-RUN rm -Rf frankenphp/
+RUN rm -Rf "$BUILD_DIR"/frankenphp/
 
 RUN set -eux; \
 	mkdir -p var/cache var/log; \

--- a/docs/custom-directory.md
+++ b/docs/custom-directory.md
@@ -1,0 +1,15 @@
+## Specifiy Build directory
+
+If you want to place this repository in a subdirectory you can specify the `BUILD_ARGS` in your `compose.prod.yaml` AND `compose.override.yaml`.
+
+```yaml
+services:
+  php:
+    build:
+      context: . # <-- Adapt the context to the root level of your project
+      target: frankenphp_dev
+      args:
+          BUILD_DIR: "docker" # <-- Specifiy the subdirectory where this repository is placed
+    volumes:
+      - ./:/app # <-- Adapt the mount volume to the directory specified 
+```


### PR DESCRIPTION
Probably not everyone wants to place the build related files on root level of their development project.

To enhance flexibility the build directory can be specified.
No further adaptions are required for the Dockerfile.

To make it work the Dockerfile needs an argument and adaptios to the yamls for proper volume mounts are required. Therefore i have added the Dockerfile arg and the related doc.

Happy to discuss