### PR TITLE
Update 20-app.prod.ini

### DIFF
--- a/frankenphp/conf.d/20-app.prod.ini
+++ b/frankenphp/conf.d/20-app.prod.ini
@@ -1,2 +1,5 @@
+; https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
 opcache.preload_user = root
 opcache.preload = /app/config/preload.php
+; https://symfony.com/doc/current/performance.html#don-t-check-php-files-timestamps
+opcache.validate_timestamps = 0


### PR DESCRIPTION
hello,

as the page symfony performance [is linked here](https://github.com/dunglas/symfony-docker/blob/5a973670e1ab869f0531fc10b9cbe82229736d9b/frankenphp/conf.d/10-app.ini#L7)
when reading it I saw also this `opcache.validate_timestamps = 0` config

do you think it is worth adding it here as well?

thank you,