### PR TITLE
feat: activate the watch mode in dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile" ]
 FROM frankenphp_base AS frankenphp_dev
 
 ENV APP_ENV=dev XDEBUG_MODE=off
+ENV FRANKENPHP_CONFIG="import dev.worker.Caddyfile"
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
@@ -63,6 +64,7 @@ RUN set -eux; \
 	;
 
 COPY --link frankenphp/conf.d/20-app.dev.ini $PHP_INI_DIR/app.conf.d/
+COPY --link frankenphp/dev.worker.Caddyfile /etc/caddy/dev.worker.Caddyfile
 
 CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
 

--- a/frankenphp/dev.worker.Caddyfile
+++ b/frankenphp/dev.worker.Caddyfile
@@ -1,0 +1,5 @@
+worker {
+	file ./public/index.php
+	env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
+	watch
+}


### PR DESCRIPTION
hey

the blog post https://dunglas.dev/2024/11/frankenphp-1-3-massive-performance-improvements-watcher-mode-dedicated-prometheus-metrics-and-more/ 
the paragraph "File Watchers" talks about this feature `watch`

Questions:

1. is it good here? no overhead for `prod`
2. otherwise, how to differentiate a `worker.Caddyfile` from `dev` or `prod` ?
    - creating a `ENV FRANKENPHP_CONFIG="import dev.worker.Caddyfile"` inside the `frankenphp_dev`
3. actually what is the best way with current image/container to see live file changes of symfony app?
    - with running `docker compose up --watch` after `docker compose build --no-cache --pull` ?

thank you,