### PR TITLE
Added project initializability check in `docker-entrypoint.sh`

### DIFF
--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -26,6 +26,10 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		composer install --prefer-dist --no-progress --no-interaction
 	fi
 
+	# Display information about the current project
+	# Or about an error in project initialization
+	php bin/console -V
+
 	if grep -q ^DATABASE_URL= .env; then
 		echo 'Waiting for database to be ready...'
 		ATTEMPTS_LEFT_TO_REACH_DATABASE=60


### PR DESCRIPTION
Currently, if there are errors that prevent the project from initializing correctly, the php container console shows a database connection error (see https://github.com/dunglas/symfony-docker/issues/718).

With this PR, I propose adding a check to ensure that the project can be initialized before checking the database connection. This will allow you to see a specific error in the php container console.