### PR TITLE
Update docker bake action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Build Docker images
-        uses: docker/bake-action@v4
+        uses: docker/bake-action@v6
         with:
           pull: true
           load: true


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/57920ecd-0e00-48af-bba5-c15e97ae9d04)

---

I encountered an error in one of my private repositories based on the Symfony Docker template. The issue occurred when using `docker/bake-action < v5` with `buildx >= 0.20.0`.

#### Error message:

### Solution
Updating `docker/bake-action` from `v4` to `v6` resolved the issue.

### Changes made:
- Updated `docker/bake-action` version in the workflow file from `v4` to `v6`.

### Testing
- Verified that the workflows now run successfully without errors.
