### PR TITLE
fix (Makefile): Configure editor to use tabs by default

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -55,3 +55,6 @@ indent_style = tab
 
 [*.*Caddyfile]
 indent_style = tab
+
+[Makefile]
+indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -55,6 +55,3 @@ indent_style = tab
 
 [*.*Caddyfile]
 indent_style = tab
-
-[Makefile]
-indent_style = tab

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -95,3 +95,16 @@ sf: ## List all Symfony commands or pass the parameter "c=" to run a given comma
 cc: c=c:c ## Clear the cache
 cc: sf
 ```
+
+## Adding and modifying jobs
+
+Make sure to add this configuration to the [.editorconfig](/.editorconfig) file, so that it forces your editor to use tabs instead of spaces (Makefiles are not compatible with spaces by default).
+
+```.editorconfig
+
+[Makefile]
+indent_style = tab
+
+```
+
+If you still want to use space, you can configure the prefix in the Makefile itself. See [this answer on StackExchange](https://retrocomputing.stackexchange.com/a/20303).


### PR DESCRIPTION
Add indent style to tabs when editing Makefiles.

Makefiles does not work with spaces.