### PR TITLE
feat: enable workers in dev (watchers)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,9 @@ CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile" ]
 # Dev FrankenPHP image
 FROM frankenphp_base AS frankenphp_dev
 
-ENV APP_ENV=dev XDEBUG_MODE=off
+ENV APP_ENV=dev
+ENV XDEBUG_MODE=off
+ENV FRANKENPHP_WORKER_CONFIG=watch
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
@@ -70,7 +72,6 @@ CMD [ "frankenphp", "run", "--config", "/etc/caddy/Caddyfile", "--watch" ]
 FROM frankenphp_base AS frankenphp_prod
 
 ENV APP_ENV=prod
-ENV FRANKENPHP_CONFIG="import worker.Caddyfile"
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -12,6 +12,7 @@ services:
       #  from the bind-mount for better performance by enabling the next line:
       #- /app/vendor
     environment:
+      FRANKENPHP_WORKER_CONFIG: watch
       MERCURE_EXTRA_DIRECTIVES: demo
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"

--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -3,6 +3,12 @@
 
 	frankenphp {
 		{$FRANKENPHP_CONFIG}
+
+		worker {
+			file ./public/index.php
+			env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
+			{$FRANKENPHP_WORKER_CONFIG}
+		}
 	}
 }
 

--- a/frankenphp/worker.Caddyfile
+++ b/frankenphp/worker.Caddyfile
@@ -1,4 +1,0 @@
-worker {
-	file ./public/index.php
-	env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
-}


### PR DESCRIPTION
Use the new "watcher" feature of FrankenPHP 1.4 to enable the worker mode in dev. Workers are automatically restarted when a file change.
