### PR TITLE
Update Mercure configuration in Caddyfile

### DIFF
--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -23,8 +23,6 @@
 	encode zstd br gzip
 
 	mercure {
-		# Transport to use (default to Bolt)
-		transport_url {$MERCURE_TRANSPORT_URL:bolt:///data/mercure.db}
 		# Publisher JWT key
 		publisher_jwt {env.MERCURE_PUBLISHER_JWT_KEY} {env.MERCURE_PUBLISHER_JWT_ALG}
 		# Subscriber JWT key


### PR DESCRIPTION
Due to https://github.com/dunglas/mercure/pull/939 and the deprecation message, it makes sense to apply the Mercure configuration changes.

See:
- [Upgrade notice](https://github.com/dunglas/mercure/blob/main/docs/UPGRADE.md#017)
- [Original patch](https://github.com/dunglas/mercure/pull/939/commits/114044ee0fb80ebcb89c9f1f435a7f9fc422b911#diff-1f38639fad43624b85cdc2cac1778918713a061084bca6487683ec73f2b29fea)