### PR TITLE
Add default value of the `MERCURE_TRANSPORT_URL` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ RUN set -eux; \
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
+# Transport to use by Mercure (default to Bolt)
+ENV MERCURE_TRANSPORT_URL=bolt:///data/mercure.db
+
 ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
 
 ###> recipes ###


### PR DESCRIPTION
After https://github.com/dunglas/symfony-docker/pull/766 the path for Mercure became `./bolt.db`, ​​which is different from what it was before (`/data/mercure.db`). This PR reverts the path back to the previous value.