### PR TITLE
fix: do not use non-existent FrankenPHP worker config file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,6 @@ ENV APP_ENV=prod
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 COPY --link frankenphp/conf.d/20-app.prod.ini $PHP_INI_DIR/app.conf.d/
-COPY --link frankenphp/worker.Caddyfile /etc/caddy/worker.Caddyfile
 
 # prevent the reinstallation of vendors at every changes in the source code
 COPY --link composer.* symfony.* ./


### PR DESCRIPTION
Fix #769