### PR TITLE
chore: normalize docker compose commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ with [FrankenPHP](https://frankenphp.dev) and [Caddy](https://caddyserver.com/) 
 ## Getting Started
 
 1. If not already done, [install Docker Compose](https://docs.docker.com/compose/install/) (v2.10+)
-2. Run `docker compose build --no-cache` to build fresh images
-3. Run `docker compose up --pull always -d --wait` to set up and start a fresh Symfony project
+2. Run `docker compose build --pull --no-cache` to build fresh images
+3. Run `docker compose up --wait` to set up and start a fresh Symfony project
 4. Open `https://localhost` in your favorite web browser and [accept the auto-generated TLS certificate](https://stackoverflow.com/a/15076602/1352334)
 5. Run `docker compose down --remove-orphans` to stop the Docker containers.
 

--- a/docs/existing-project.md
+++ b/docs/existing-project.md
@@ -29,11 +29,11 @@ Double-check the changes, revert the changes that you don't want to keep:
 
 Build the Docker images:
 
-    docker compose build --no-cache --pull
+    docker compose build --pull --no-cache
 
 Start the project!
 
-    docker compose up -d
+    docker compose up --wait
 
 Browse `https://localhost`, your Docker configuration is ready!
 

--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -74,7 +74,7 @@ docker compose down --remove-orphans && docker compose build --pull --no-cache
 
 Start the services:
 ```shell
-docker compose up -d
+docker compose up --wait
 ```
 
 Test your setup:

--- a/docs/options.md
+++ b/docs/options.md
@@ -13,10 +13,10 @@ For instance, use the following command to install Symfony 6.4:
 
 On Linux:
 
-    SYMFONY_VERSION=6.4.* docker compose up -d --wait
+    SYMFONY_VERSION=6.4.* docker compose up --wait
 On Windows:
 
-    set SYMFONY_VERSION=6.4.* && docker compose up -d --wait&set SYMFONY_VERSION=
+    set SYMFONY_VERSION=6.4.* && docker compose up --wait&set SYMFONY_VERSION=
 
 ## Installing Development Versions of Symfony
 
@@ -27,17 +27,17 @@ For instance, use the following command to use the development branch of Symfony
 
 On Linux:
 
-    STABILITY=dev docker compose up -d --wait
+    STABILITY=dev docker compose up --wait
 
 On Windows:
     
-    set STABILITY=dev && docker compose up -d --wait&set STABILITY=
+    set STABILITY=dev && docker compose up --wait&set STABILITY=
 
 ## Using custom HTTP ports
 
 Use the environment variables `HTTP_PORT`, `HTTPS_PORT` and/or `HTTP3_PORT` to adjust the ports to your needs, e.g.
 
-    HTTP_PORT=8000 HTTPS_PORT=4443 HTTP3_PORT=4443 docker compose up -d --wait
+    HTTP_PORT=8000 HTTPS_PORT=4443 HTTP3_PORT=4443 docker compose up --wait
 
 to access your application on [https://localhost:4443](https://localhost:4443).
 
@@ -69,4 +69,4 @@ You can also customize the `Caddyfile` by using the following environment variab
 
 ### Example of server name customize:
 
-    SERVER_NAME="app.localhost" docker compose up -d --wait
+    SERVER_NAME="app.localhost" docker compose up --wait

--- a/docs/production.md
+++ b/docs/production.md
@@ -61,13 +61,13 @@ Go into the directory containing your project (`<project-name>`), and start the 
 
 ```console
 # Build fresh production image
-docker compose -f compose.yaml -f compose.prod.yaml build --no-cache
+docker compose -f compose.yaml -f compose.prod.yaml build --pull --no-cache
 
 # Start container
 SERVER_NAME=your-domain-name.example.com \
 APP_SECRET=ChangeMe \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
-docker compose -f compose.yaml -f compose.prod.yaml up -d --wait
+docker compose -f compose.yaml -f compose.prod.yaml up --wait
 ```
 
 Be sure to replace `your-domain-name.example.com` with your actual domain name and to set the values of `APP_SECRET`, `CADDY_MERCURE_JWT_SECRET` to cryptographically secure random values.
@@ -89,7 +89,7 @@ Alternatively, if you don't want to expose an HTTPS server but only an HTTP one,
 SERVER_NAME=:80 \
 APP_SECRET=ChangeMe \
 CADDY_MERCURE_JWT_SECRET=ChangeThisMercureHubJWTSecretKey \
-docker compose -f compose.yaml -f compose.prod.yaml up -d --wait
+docker compose -f compose.yaml -f compose.prod.yaml up --wait
 ```
 
 ## Deploying on Multiple Nodes

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -45,7 +45,7 @@ To disable HTTPS, configure your environment to use HTTP by setting the followin
 ```bash
 SERVER_NAME=http://localhost \
 MERCURE_PUBLIC_URL=http://localhost/.well-known/mercure \
-docker compose up --pull always -d --wait
+docker compose up --wait
 ```
 
 Ensure your application is accessible over HTTP by visiting `http://localhost` in your web browser.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,13 +12,13 @@ See more in the [TLS section](tls.md)
 
 ### How to properly build fresh images for production use
 
-Remember that, by default, if you run `docker compose up -d`, only the files `compose.yaml` and `compose.override.yaml` will be used.
+Remember that, by default, if you run `docker compose up --wait`, only the files `compose.yaml` and `compose.override.yaml` will be used.
 See https://docs.docker.com/compose/intro/compose-application-model and https://docs.docker.com/compose/how-tos/multiple-compose-files/merge.
 
 If you need to build images for production environment, you have to use the following command:
 
 ```console
-docker compose -f compose.yaml -f compose.prod.yaml build --no-cache
+docker compose -f compose.yaml -f compose.prod.yaml build --pull --no-cache
 ```
 
 ### Why application outputs `phpinfo()`
@@ -27,7 +27,7 @@ Both dev and prod images have the same image tag (`<...>app-php:latest`). This c
 It is important to make sure that your image is the appropriate one for the current environment.
 
 If you are not careful about this, and try to run your production container(s) with
-`docker compose -f compose.yaml -f compose.prod.yaml up -d`
+`docker compose -f compose.yaml -f compose.prod.yaml up --wait`
 without the right build process beforehand, your application **will still launch**, but will be displaying an output of `phpinfo()` (or possibly even a HTTP 500 error page).
 
 See details below.
@@ -45,7 +45,7 @@ Which is good enough for dev purposes.
 Then, you can start your dev container(s) by running:
 
 ```console
-docker compose up -d
+docker compose up --wait
 ```
 
 
@@ -58,7 +58,7 @@ docker compose up -d
 <summary>Output expected for the production build process</summary>
 
 To build the production image, you <ins>have to</ins> specify the `compose.yaml` and `compose.prod.yaml` files.
-This means you have to run: `docker compose -f compose.yaml -f compose.prod.yaml build` in order to build your image
+This means you have to run: `docker compose -f compose.yaml -f compose.prod.yaml build --pull --no-cache` in order to build your image
 (careful: the order of `-f` arguments is important).
 
 That way, you will see that `frankenphp_base` and `frankenphp_prod` are built this time, which is what you will need for production purposes.
@@ -66,7 +66,7 @@ That way, you will see that `frankenphp_base` and `frankenphp_prod` are built th
 You can finally start your prod container(s) by running:
 
 ```console
-docker compose -f compose.yaml -f compose.prod.yaml up -d
+docker compose -f compose.yaml -f compose.prod.yaml up --wait
 ```
 
 </details>

--- a/docs/xdebug.md
+++ b/docs/xdebug.md
@@ -9,13 +9,13 @@ It can be enabled by setting the `XDEBUG_MODE` environment variable to `debug`.
 On Linux and Mac:
 
 ```
-XDEBUG_MODE=debug docker compose up -d
+XDEBUG_MODE=debug docker compose up --wait
 ```
 
 On Windows:
 
 ```
-set XDEBUG_MODE=debug&& docker compose up -d&set XDEBUG_MODE=
+set XDEBUG_MODE=debug&& docker compose up --wait&set XDEBUG_MODE=
 ```
 
 ## Debugging with Xdebug and PHPStorm

--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -17,7 +17,7 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		composer config --json extra.symfony.docker 'true'
 
 		if grep -q ^DATABASE_URL= .env; then
-			echo 'To finish the installation please press Ctrl+C to stop Docker Compose and run: docker compose up --build -d --wait'
+			echo 'To finish the installation please press Ctrl+C to stop Docker Compose and run: docker compose up --build --wait'
 			sleep infinity
 		fi
 	fi


### PR DESCRIPTION
Part of #776

This PR brings the following commands to uniform formats:

* `docker compose ... build --pull --no-cache`

    * The options are set in this order (this order was more common in this template).

* `docker compose ... up --wait`

    * Specifying the `-d` option is optional (the `--wait` option implies the `-d` option, see https://github.com/dunglas/symfony-docker/issues/436#issuecomment-2792914977).

* `docker compose ... down --remove-orphans`

    Already in a unified format.