### PR TITLE
Fix .editorconfig to support Caddyfile and docker compose files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -47,11 +47,11 @@ indent_size = 4
 [composer.json]
 indent_size = 4
 
-[{compose,docker-compose}.*.{yaml,yml}]
+[{compose,docker-compose}.{*.yaml,*.yml,yaml,yml}]
 indent_size = 2
 
 [*.*Dockerfile]
 indent_style = tab
 
-[*.*Caddyfile]
+[{Caddyfile,*.*Caddyfile}]
 indent_style = tab


### PR DESCRIPTION
Docker compose:
`compose.{yml,yaml}` and `docker-compose.{yml,yaml}` was not supported, fixed

Caddyfile:
`Caddyfile` was not supported, fixed