### PR TITLE
Mark /app as safe directory for Git

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
         name: Start services
         run: docker compose up --wait --no-build
       -
+        name: Mark /app as safe directory for Git
+        run: docker compose exec -T php git config --global --add safe.directory /app
+      -
         name: Check HTTP reachability
         run: curl -v --fail-with-body http://localhost
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,6 @@ jobs:
         name: Start services
         run: docker compose up --wait --no-build
       -
-        name: Mark /app as safe directory for Git
-        run: docker compose exec -T php git config --global --add safe.directory /app
-      -
         name: Check HTTP reachability
         run: curl -v --fail-with-body http://localhost
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,9 @@ ENV APP_ENV=dev
 ENV XDEBUG_MODE=off
 ENV FRANKENPHP_WORKER_CONFIG=watch
 
-RUN git config --global --add safe.directory /app
-
-RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+RUN set -eux; \
+	git config --global --add safe.directory /app; \
+	mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 RUN set -eux; \
 	install-php-extensions \

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ ENV APP_ENV=dev
 ENV XDEBUG_MODE=off
 ENV FRANKENPHP_WORKER_CONFIG=watch
 
+RUN git config --global --add safe.directory /app
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ ENV XDEBUG_MODE=off
 ENV FRANKENPHP_WORKER_CONFIG=watch
 
 RUN git config --global --add safe.directory /app
+
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 RUN set -eux; \


### PR DESCRIPTION
In my github actions I got error

```
The repository at "/app" does not have the correct ownership and git refuses to use it:

fatal: detected dubious ownership in repository at '/app'
To add an exception for this directory, call:

	git config --global --add safe.directory /app
```

This PR fixes the issue by adding an actions to mark /app directory as safe for git.