### PR TITLE
feat(docker): add Symfony CLI in php image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,9 @@ ENV APP_ENV=dev
 ENV XDEBUG_MODE=off
 ENV FRANKENPHP_WORKER_CONFIG=watch
 
+RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' |  bash 
+RUN apt install symfony-cli
+
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 RUN set -eux; \


### PR DESCRIPTION
- Install Symfony CLI only in the frankenphp_dev target
- Allows running `symfony console` commands inside the dev container
- Keeps the production image lighter since Symfony CLI is not required there