### PR TITLE
deps: remove unnecessary dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,9 +18,7 @@ VOLUME /app/var/
 # persistent / runtime deps
 # hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
-	acl \
 	file \
-	gettext \
 	git \
 	&& rm -rf /var/lib/apt/lists/*
 

--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -16,16 +16,12 @@ To switch to Alpine-based images, apply the following changes to the `Dockerfile
 
 -# hadolint ignore=DL3008
 -RUN apt-get update && apt-get install -y --no-install-recommends \
--	acl \
 -	file \
--	gettext \
 -	git \
 -	&& rm -rf /var/lib/apt/lists/*
 +# hadolint ignore=DL3018
 +RUN apk add --no-cache \
-+	acl \
 +	file \
-+	gettext \
 +	git
 ```
 

--- a/frankenphp/docker-entrypoint.sh
+++ b/frankenphp/docker-entrypoint.sh
@@ -57,9 +57,6 @@ if [ "$1" = 'frankenphp' ] || [ "$1" = 'php' ] || [ "$1" = 'bin/console' ]; then
 		fi
 	fi
 
-	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var
-	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var
-
 	echo 'PHP app ready!'
 fi
 


### PR DESCRIPTION
I suggest removing the following dependencies:
- `acl`
- `gettext`

These dependencies are not used or have no useful functionality.

See https://github.com/dunglas/symfony-docker/discussions/819