### PR TITLE
feat: add `DEFAULT_URI` environment variable

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,7 @@ services:
     restart: unless-stopped
     environment:
       SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
+      DEFAULT_URI: https://${SERVER_NAME:-localhost}:${HTTPS_PORT:-443}
       MERCURE_PUBLISHER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       MERCURE_SUBSCRIBER_JWT_KEY: ${CADDY_MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
       # Run "composer require symfony/orm-pack" to install and configure Doctrine ORM


### PR DESCRIPTION
The `DEFAULT_URI` environment variable was added to the Symfony Router recipe to set the value of the `router.default_uri` configuration option (see https://github.com/symfony/recipes/pull/1416). This PR sets the value of this environment variable.