### PR TITLE
chore: name ports in compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -20,16 +20,16 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     ports:
-      # HTTP
-      - target: 80
+      - name: http
+        target: 80
         published: ${HTTP_PORT:-80}
         protocol: tcp
-      # HTTPS
-      - target: 443
+      - name: https
+        target: 443
         published: ${HTTPS_PORT:-443}
         protocol: tcp
-      # HTTP/3
-      - target: 443
+      - name: http3
+        target: 443
         published: ${HTTP3_PORT:-443}
         protocol: udp
 


### PR DESCRIPTION
Docker Compose has a special attribute `port.name` for naming ports. I suggest using this attribute instead of port comments.

See https://github.com/compose-spec/compose-spec/pull/464