### PR TITLE
Fix Composer installation by using OpenSSL 3.0.17 in FrankenPHP base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #syntax=docker/dockerfile:1
 
 # Versions
-FROM dunglas/frankenphp:1-php8.4 AS frankenphp_upstream
+FROM dunglas/frankenphp:1.9.0-php8.4 AS frankenphp_upstream
 
 # The different stages of this Dockerfile are meant to be built into separate images
 # https://docs.docker.com/develop/develop-images/multistage-build/#stop-at-a-specific-build-stage


### PR DESCRIPTION
**Description:**
The build of the Symfony Docker image fails at the step `install-php-extensions @composer` with the following error:

```
curl: (35) Recv failure: Connection reset by peer
```

This is caused by the OpenSSL version `3.5.1` included in `dunglas/frankenphp:1-php8.4`, which breaks HTTPS connections to `https://repo.packagist.org`.

To fix this, I propose switching the base image to a version of FrankenPHP that still uses OpenSSL `3.0.17`. This allows Composer to successfully connect and install dependencies over HTTPS.

**Changes:**

* Use `dunglas/frankenphp:1.9.0-php8.4` as the base image instead of the current one that ships OpenSSL 3.5.1.

**Impact:**

* Composer installation will work correctly during the Docker build.
* No changes to application code are required.
 