### PR TITLE
chore: prevent useless git pull in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           pull: true
           load: true
+          source: .
           files: |
             compose.yaml
             compose.override.yaml


### PR DESCRIPTION
Since v6, the Bake action automatically pulls the Git repository: https://github.com/docker/bake-action?tab=readme-ov-file#git-context

This patch forces it to use the local files.