### PR TITLE
feat: use `COPY --exclude` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,7 @@ RUN set -eux; \
 	composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
 
 # copy sources
-COPY --link . ./
-RUN rm -Rf frankenphp/
+COPY --link --exclude=frankenphp/ . ./
 
 RUN set -eux; \
 	mkdir -p var/cache var/log; \


### PR DESCRIPTION
As of Dockerfile 1.19, `COPY --exclude` is no longer experimental. It can be used instead of a additional layer of deleting the `frankenphp` dir.

Suggested erlier in https://github.com/dunglas/symfony-docker/pull/861#discussion_r2461078951