### PR TITLE
Fix doctrine mysql deprecation

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -20,7 +20,7 @@ Change the database image to use MySQL instead of PostgreSQL in `compose.yaml`:
 ```diff
  ###> doctrine/doctrine-bundle ###
 -    image: postgres:${POSTGRES_VERSION:-16}-alpine
-+    image: mysql:${MYSQL_VERSION:-8}
++    image: mysql:${MYSQL_VERSION:-8.0.32}
      environment:
 -      POSTGRES_DB: ${POSTGRES_DB:-app}
 +      MYSQL_DATABASE: ${MYSQL_DATABASE:-app}
@@ -51,7 +51,7 @@ Depending on the database configuration,
 modify the environment in the same file at `services.php.environment.DATABASE_URL`:
 
 ```yaml
-DATABASE_URL: mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=${MYSQL_VERSION:-8}&charset=${MYSQL_CHARSET:-utf8mb4}
+DATABASE_URL: mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=${MYSQL_VERSION:-8.0.32}&charset=${MYSQL_CHARSET:-utf8mb4}
 ```
 
 Since we changed the port, we also have to define this in the `compose.override.yaml`:
@@ -79,7 +79,7 @@ Last but not least, we need to install the MySQL driver in `Dockerfile`:
 Change the database configuration in `.env`:
 
 ```dotenv
-DATABASE_URL=mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=${MYSQL_VERSION:-8}&charset=${MYSQL_CHARSET:-utf8mb4}
+DATABASE_URL=mysql://${MYSQL_USER:-app}:${MYSQL_PASSWORD:-!ChangeMe!}@database:3306/${MYSQL_DATABASE:-app}?serverVersion=${MYSQL_VERSION:-8.0.32}&charset=${MYSQL_CHARSET:-utf8mb4}
 ```
 
 ## Final steps


### PR DESCRIPTION
After following the docs to switch from Postgres to MySQL on a fresh project with `symfony/orm-pack` installed, (and `MYSQL_VERSION` env var is not defined meaning it falls back to the default version), I noticed this deprecation when running `bin/console doctrine:schema:validate -vvv`:
```
User Deprecated: Version detection logic for MySQL will change in DBAL 4. Please specify the version as the server reports it, e.g. "8.0.31" instead of "8". (AbstractMySQLDriver.php:94 called by AbstractDriverMiddleware.php:68, https://github.com/doctrine/dbal/pull/5779, package doctrine/orm)
```
The reason I went for `8.0.32` is because when the new project is scaffolded, the `.env` file specifies version 8.0.32 by default because of the doctrine-bundle recipe, so it makes sense that it would match.

https://github.com/symfony/recipes/blob/main/doctrine/doctrine-bundle/2.13/manifest.json#L14

```
"#5": "DATABASE_URL=\"mysql://app:!ChangeMe!@127.0.0.1:3306/app?serverVersion=8.0.32&charset=utf8mb4\"",
```