### PR TITLE
fix(lint): Ignore always-false condition errors in ci workflow

### DIFF
--- a/.github/linters/actionlint.yaml
+++ b/.github/linters/actionlint.yaml
@@ -1,0 +1,5 @@
+---
+paths:
+  .github/workflows/ci.yaml:
+    ignore:
+      - 'condition "false" is always evaluated to false. remove the if:.+'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: Lint Code Base
         uses: super-linter/super-linter/slim@v8
         env:
+          GITHUB_ACTIONS_CONFIG_FILE: actionlint.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_CHECKOV: false
           VALIDATE_TRIVY: false


### PR DESCRIPTION
Since actionlint v1.7.9 (see https://github.com/rhysd/actionlint/releases/tag/v1.7.9) using constants in `if` is now considered an error.

With this PR, I propose to ignore the error about using the constant `false` in an `if` for the file `.github/workflows/ci.yaml`.