### PR TITLE
Install xdebug through PIE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	git \
 	&& rm -rf /var/lib/apt/lists/*
 
+COPY --from=ghcr.io/php/pie:bin /pie /usr/bin/pie
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
 RUN set -eux; \
 	install-php-extensions \
-		@composer \
 		apcu \
 		intl \
 		opcache \
@@ -60,10 +62,7 @@ ENV FRANKENPHP_WORKER_CONFIG=watch
 
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
-RUN set -eux; \
-	install-php-extensions \
-		xdebug \
-	;
+RUN pie install xdebug/xdebug
 
 COPY --link frankenphp/conf.d/20-app.dev.ini $PHP_INI_DIR/app.conf.d/
 


### PR DESCRIPTION
And take a leap in the future 🚀  It's a lot faster as through `install-php-extensions`.

XDebug 3.5 with PHP 8.5 support just was released, and mentions using PIE as a recommended method: https://github.com/xdebug/xdebug/releases/tag/3.5.0

Other extension I'm successfully installing for dev / production, by defining them in `composer.json` currently is `ext-zend-opcache`.