### PR TITLE
fix: Add `var/share` directory creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN set -eux; \
 COPY --link --exclude=frankenphp/ . ./
 
 RUN set -eux; \
-	mkdir -p var/cache var/log; \
+	mkdir -p var/cache var/log var/share; \
 	composer dump-autoload --classmap-authoritative --no-dev; \
 	composer dump-env prod; \
 	composer run-script --no-dev post-install-cmd; \


### PR DESCRIPTION
Since Symfony 7.4, a new `var/share` directory has been introduced for storing files shared between servers (see https://symfony.com/blog/new-in-symfony-7-4-share-directory).

This PR adds pre-creation of this new directory, similar to the `var/cache` and `var/log` directories.