### PR TITLE
Update tls.md - Using Custom TLS Certificates

### DIFF
--- a/docs/tls.md
+++ b/docs/tls.md
@@ -68,7 +68,19 @@ do as follows:
         # ...
    ```
 
-5. Restart your `php` service
+5. If you want to use HTTPS, update this line in `compose.yaml`:
+
+```console
+SERVER_NAME: ${SERVER_NAME:-localhost}, php:80
+```
+
+Replace `80` by `443`.
+
+6. Restart your `php` service using your local host:
+
+```console
+SERVER_NAME=https://server-name.localhost docker compose up --wait
+```
 
 ## Disabling HTTPS for Local Development
 


### PR DESCRIPTION
Hello,

I just updated the docs using a custom TLS certificate.
When we don't specify the `SERVER_NAME` running just `docker compose up --wait`, the container is healthy but we have this error in docker logs:
```console
php-1  | 2026/01/04 15:27:04.050	ERROR	The "MERCURE_TRANSPORT_URL"" environment variable is not supported anymore, set the "transport" directive in the "MERCURE_EXTRA_DIRECTIVES" environment variable instead
```

If we keep the `80` port in `compose.yaml`, we have this error:
```console
php-1  | Error: adapting config using caddyfile: server listening on [:80] is HTTP, but attempts to configure TLS connection policies
```

If we remove the `80` port in `compose.yaml`, we have this error:
```console
Error: adapting config using caddyfile: /etc/frankenphp/Caddyfile:19: parsed 'php' as a site address, but it is a known directive; directives must appear in a site block
```

By replacing the `80` port by `443` and using the `SERVER_NAME=https://server-name.localhost docker compose up --wait` everything seems to work.

Reproducer:
1. Create a brand fresh new project
2. Follow the `tls.md` docs using a custom certificate

WDYT ? 