### PR TITLE
bug: set max_execution_timeout to -1 for Xdebug

### DIFF
--- a/frankenphp/conf.d/20-app.dev.ini
+++ b/frankenphp/conf.d/20-app.dev.ini
@@ -3,3 +3,6 @@
 ; The `client_host` below may optionally be replaced with `discover_client_host=yes`
 ; Add `start_with_request=yes` to start debug session on each request
 xdebug.client_host = host.docker.internal
+
+; diable timeout to use xdebug with breakpoints
+max_execution_timeout = -1


### PR DESCRIPTION
Disable timeout for Xdebug to allow breakpoints.

see also https://github.com/dunglas/symfony-docker/discussions/889