### PR TITLE
fix(lint): Ignore always-false condition errors in ci workflow again

### DIFF
--- a/.github/linters/actionlint.yaml
+++ b/.github/linters/actionlint.yaml
@@ -2,4 +2,4 @@
 paths:
   .github/workflows/ci.yaml:
     ignore:
-      - 'condition "false" is always evaluated to false. remove the if:.+'
+      - 'constant expression "false" in condition. remove the if:.+'


### PR DESCRIPTION
Actionlint's [previously ignored](https://github.com/dunglas/symfony-docker/pull/874) spurious error message has been changed (see https://github.com/rhysd/actionlint/commit/524fc0af10c1c20fec96b53075b537a1df694890).