### PR TITLE
perf: Reuse APT cache for `install-php-extensions`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ RUN set -eux; \
 		file \
 		git \
 	; \
-	rm -rf /var/lib/apt/lists/*; \
 	install-php-extensions \
 		@composer \
 		apcu \


### PR DESCRIPTION
The `install-php-extensions` command internally executes the `apt-get update`. The APT cache was already retrieved in this step earlier. Delaying the APT cache clearing will allow `install-php-extensions` to reuse the APT cache.

This change should speed up the dependency installation step.