### PR TITLE
Update tls.md with Firefox certificate warning

### DIFF
--- a/docs/tls.md
+++ b/docs/tls.md
@@ -7,6 +7,9 @@ generated in the Caddy container is not trusted by your local machine.
 
 You must add the authority to the trust store of the host.
 
+> [!WARNING]  
+> The Firefox browser currently does not trust the certificate, see https://github.com/caddyserver/caddy/issues/6891.
+
 <!-- markdownlint-disable MD013 -->
 
 ### Linux


### PR DESCRIPTION
Add warning about Firefox not trusting the certificate.