### PR TITLE
feat: enable hot reloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ mode inside a sandboxed environment.
 
 - Production, development and CI ready
 - Just 1 service by default
+- Super-readable configuration
 - Blazing-fast performance thanks to [the worker mode of FrankenPHP](https://frankenphp.dev/docs/worker/)
 - [Installation of extra Docker Compose services](docs/extra-services.md) with Symfony Flex
 - Automatic HTTPS (in dev and prod)
@@ -28,10 +29,10 @@ mode inside a sandboxed environment.
 - Real-time messaging thanks to a built-in [Mercure hub](https://symfony.com/doc/current/mercure.html)
 - [Vulcain](https://vulcain.rocks) support
 - Native [XDebug](docs/xdebug.md) integration
-- Super-readable configuration
-- Rootless, slim production image
+- [Hot Reloading](https://frankenphp.dev/docs/hot-reload/)
 - [Dev Container](https://containers.dev/) support, optimized for AI coding agents
 - [Claude Code YOLO mode](docs/claude-code.md) with network-level sandboxing out of the box
+- Rootless, slim production image
 
 **Enjoy!**
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -15,6 +15,7 @@ services:
       #- /app/vendor
     environment:
       FRANKENPHP_WORKER_CONFIG: watch
+      FRANKENPHP_SITE_CONFIG: hot_reload
       MERCURE_EXTRA_DIRECTIVES: demo
       # See https://xdebug.org/docs/all_settings#mode
       XDEBUG_MODE: "${XDEBUG_MODE:-off}"

--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -52,6 +52,8 @@
 
 	@frontController path index.php
 	php @frontController {
+		{$FRANKENPHP_SITE_CONFIG}
+
 		worker {
 			file ./public/index.php
 			{$FRANKENPHP_WORKER_CONFIG}


### PR DESCRIPTION
Put this in the head of `templates/base.html.twig` to enable it:

```twig
        {% if app.request.server.has('FRANKENPHP_HOT_RELOAD') %}
            <meta name="frankenphp-hot-reload:url" content="{{ app.request.server.get('FRANKENPHP_HOT_RELOAD') }}">
            <script src="https://cdn.jsdelivr.net/npm/idiomorph"></script>
            <script src="https://cdn.jsdelivr.net/npm/frankenphp-hot-reload/+esm" type="module"></script>
        {% endif %}
```