### PR TITLE
fix: remove --link from COPY --chown to fix prod build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -162,7 +162,7 @@ RUN <<-EOF
 EOF
 
 COPY --link --exclude=var --from=frankenphp_prod_builder /app /app
-COPY --link --chown=www-data:www-data --from=frankenphp_prod_builder /app/var /app/var
+COPY --chown=www-data:www-data --from=frankenphp_prod_builder /app/var /app/var
 
 COPY --link --chmod=755 frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 


### PR DESCRIPTION
## Summary

- Remove `--link` flag from the `COPY --chown=www-data:www-data` instruction in the `frankenphp_prod` stage to fix a build failure

## Problem

The production image build fails with:

```
> [frankenphp_prod 16/18] COPY --link --chown=www-data:www-data --from=frankenphp_prod_builder /app/var /app/var:
error: invalid user index: -1
```

## Root cause

`COPY --link` creates a layer that is independent of the image context. With `--link`, name-based resolution of `--chown` (here `www-data`) can fail because the linked layer does not have access to `/etc/passwd` from the base image to resolve users and groups.

The preceding `COPY --link --exclude=var --from=frankenphp_prod_builder /app /app` works fine because it does not use `--chown`.

## Fix

Remove `--link` from this single instruction. Without `--link`, the `COPY` executes in the normal layer context where `www-data` is available, and `--chown` works as expected.

```diff
- COPY --link --chown=www-data:www-data --from=frankenphp_prod_builder /app/var /app/var
+ COPY --chown=www-data:www-data --from=frankenphp_prod_builder /app/var /app/var
```

The only trade-off is a minor reduction in layer cache efficiency for this single instruction, which is negligible.
