### PR TITLE
fix: scope /app/var volume to dev, fix prod arbitrary-UID writability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,6 @@ SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 
 WORKDIR /app
 
-VOLUME /app/var/
-
 # persistent deps
 # hadolint ignore=DL3008
 RUN <<-EOF
@@ -164,9 +162,11 @@ EOF
 COPY --link --exclude=var --from=frankenphp_prod_builder /app /app
 COPY --chown=www-data:www-data --from=frankenphp_prod_builder /app/var /app/var
 
-COPY --link --chmod=755 frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
+# Allow arbitrary UIDs (e.g. OpenShift, restricted SCCs) to write under /app/var:
+# assign the tree to group 0 and mirror owner perms to the group.
+RUN chgrp -R 0 /app/var && chmod -R g=u /app/var
 
-VOLUME /app/var/
+COPY --link --chmod=755 frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 
 USER www-data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -106,8 +106,6 @@ RUN <<-EOF
 		php bin/console asset-map:compile
 	fi
 	chmod +x bin/console
-	# Mirror owner perms to group so arbitrary UIDs running under group 0
-	# (e.g. OpenShift, restricted Kubernetes SCCs) can write under var/.
 	chmod -R g=u var
 	sync
 EOF
@@ -164,11 +162,7 @@ RUN <<-EOF
 EOF
 
 COPY --link --exclude=var --from=frankenphp_prod_builder /app /app
-# Group 0 + g=u perms (set in the builder) let containers running under
-# arbitrary UIDs (OpenShift, restricted Kubernetes SCCs) write under /app/var,
-# while USER www-data keeps working as the owner. COPY re-creates the top-level
-# /app/var directory with default 0755, so restore group-write on just that one
-# entry (single-directory metadata layer, no recursive rewrite).
+# Group 0 + g=u for arbitrary-UID runtimes (e.g. OpenShift).
 COPY --chown=www-data:0 --from=frankenphp_prod_builder /app/var /app/var
 RUN chmod g=u /app/var
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,7 +105,11 @@ RUN <<-EOF
 	if [ -f importmap.php ]; then
 		php bin/console asset-map:compile
 	fi
-	chmod +x bin/console; sync
+	chmod +x bin/console
+	# Mirror owner perms to group so arbitrary UIDs running under group 0
+	# (e.g. OpenShift, restricted Kubernetes SCCs) can write under var/.
+	chmod -R g=u var
+	sync
 EOF
 
 # Collect shared libraries needed by FrankenPHP and PHP extensions
@@ -160,11 +164,13 @@ RUN <<-EOF
 EOF
 
 COPY --link --exclude=var --from=frankenphp_prod_builder /app /app
-COPY --chown=www-data:www-data --from=frankenphp_prod_builder /app/var /app/var
-
-# Allow arbitrary UIDs (e.g. OpenShift, restricted SCCs) to write under /app/var:
-# assign the tree to group 0 and mirror owner perms to the group.
-RUN chgrp -R 0 /app/var && chmod -R g=u /app/var
+# Group 0 + g=u perms (set in the builder) let containers running under
+# arbitrary UIDs (OpenShift, restricted Kubernetes SCCs) write under /app/var,
+# while USER www-data keeps working as the owner. COPY re-creates the top-level
+# /app/var directory with default 0755, so restore group-write on just that one
+# entry (single-directory metadata layer, no recursive rewrite).
+COPY --chown=www-data:0 --from=frankenphp_prod_builder /app/var /app/var
+RUN chmod g=u /app/var
 
 COPY --link --chmod=755 frankenphp/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -10,6 +10,9 @@ services:
       - ./:/app
       - ./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile:ro
       - ./frankenphp/conf.d/20-app.dev.ini:/usr/local/etc/php/app.conf.d/20-app.dev.ini:ro
+      # Store var/ (Symfony cache, logs, sessions) in an anonymous volume instead of the ./:/app bind mount
+      # for faster I/O on Mac and Windows. Comment the next line to inspect var/ from the host.
+      - /app/var
       # If you develop on Mac or Windows you can remove the vendor/ directory
       #  from the bind-mount for better performance by enabling the next line:
       #- /app/vendor

--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -10,8 +10,7 @@ services:
       - ./:/app
       - ./frankenphp/Caddyfile:/etc/frankenphp/Caddyfile:ro
       - ./frankenphp/conf.d/20-app.dev.ini:/usr/local/etc/php/app.conf.d/20-app.dev.ini:ro
-      # Store var/ (Symfony cache, logs, sessions) in an anonymous volume instead of the ./:/app bind mount
-      # for faster I/O on Mac and Windows. Comment the next line to inspect var/ from the host.
+      # Keep var/ off the bind-mount for faster I/O on Mac/Windows; comment to inspect from the host.
       - /app/var
       # If you develop on Mac or Windows you can remove the vendor/ directory
       #  from the bind-mount for better performance by enabling the next line:


### PR DESCRIPTION
## Summary

- Move the `/app/var` anonymous volume from the `Dockerfile` to `compose.override.yaml` (next to the existing `/app/vendor` hint). It was only there to avoid slow bind-mount I/O on macOS/Windows in dev, and leaking it into the prod image caused stale `var/cache` on redeploy (the freshly compiled cache gets shadowed by an older anonymous volume populated on first run), orphan anonymous volumes accumulating across `docker run` / compose recreate cycles, and misled operators into attaching host paths whose ownership doesn't match `www-data` (UID 33). Linux devs can now also comment the line to inspect `var/` from the host (tail logs, read compiled cache).
- Make `/app/var` group-`0` with `g=u` perms in the prod stage so containers running under arbitrary UIDs (OpenShift, restricted Kubernetes SCCs) can write to it while `USER www-data` keeps working as the default.