### PR TITLE
refactor(php): remove unnecessary `opcache.preload_user` overwrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,7 +123,6 @@ RUN <<-'EOF'
 			[ -f "$lib" ] && cp -n "$lib" /tmp/libs/
 		done
 	done
-	sed -i 's/opcache.preload_user = root/opcache.preload_user = www-data/' "$PHP_INI_DIR/app.conf.d/20-app.prod.ini"
 	rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/frankenphp/conf.d/20-app.prod.ini
+++ b/frankenphp/conf.d/20-app.prod.ini
@@ -1,5 +1,5 @@
 ; https://symfony.com/doc/current/performance.html#use-the-opcache-class-preloading
-opcache.preload_user = root
+opcache.preload_user = www-data
 opcache.preload = /app/config/preload.php
 ; https://symfony.com/doc/current/performance.html#don-t-check-php-files-timestamps
 opcache.validate_timestamps = 0


### PR DESCRIPTION
Closes https://github.com/dunglas/symfony-docker/discussions/936.