### PR TITLE
Remove Topics tracking header from Caddyfile

### DIFF
--- a/frankenphp/Caddyfile
+++ b/frankenphp/Caddyfile
@@ -41,9 +41,6 @@
 
 	{$CADDY_SERVER_EXTRA_DIRECTIVES}
 
-	# Disable Topics tracking if not enabled explicitly: https://github.com/jkarlin/topics
-	header ?Permissions-Policy "browsing-topics=()"
-
 	@phpRoute {
 		not path /.well-known/mercure*
 		not file {path}


### PR DESCRIPTION
This is not needed anymore: https://developer.mozilla.org/en-US/docs/Web/API/Topics_API