### PR TITLE
Add bin folder of app to path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ EOF
 ENV COMPOSER_ALLOW_SUPERUSER=1
 
 ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
+ENV PATH="${PATH}:/app/bin"
 
 ###> recipes ###
 ###< recipes ###


### PR DESCRIPTION
At least for me it's quite annoying to constantly write `bin/console` instead of `console`, so perhaps a simple solution would be to add the bin folder to path? 

