### PR TITLE
feat(devcontainer): default to Kilo Code, make Claude Code opt-in

### DIFF
--- a/.devcontainer/.claude/settings.json
+++ b/.devcontainer/.claude/settings.json
@@ -1,5 +1,0 @@
-{
-    "enabledPlugins": {
-        "php-lsp@claude-plugins-official": true
-    }
-}

--- a/.devcontainer/AGENTS.md
+++ b/.devcontainer/AGENTS.md
@@ -13,7 +13,7 @@ If an outbound request fails (e.g., `curl`, `composer require`, `npm install` to
 Edit `.devcontainer/init-firewall.sh` and add the domain to the `ipset=` line in the dnsmasq configuration block:
 
 ```bash
-ipset=/github.com/anthropic.com/.../NEW_DOMAIN.COM/allowed-domains
+ipset=/github.com/.../NEW_DOMAIN.COM/allowed-domains
 ```
 
 Then rebuild the Dev Container to apply the change.

--- a/.devcontainer/compose.devcontainer.yaml
+++ b/.devcontainer/compose.devcontainer.yaml
@@ -1,7 +1,7 @@
 ---
 # Dev Container-specific overrides
 # Adds capabilities required by the firewall script (init-firewall.sh)
-# that restricts Claude Code's outbound network access.
+# that restricts the coding agent's outbound network access.
 services:
   php:
     cap_add:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,22 +8,23 @@
     "service": "php",
     "workspaceFolder": "/app",
     "features": {
-        "ghcr.io/devcontainers/features/node:1": {},
-        "ghcr.io/devcontainers-extra/features/claude-code:2": {}
+        "ghcr.io/devcontainers/features/node:1": {}
     },
     "remoteUser": "nonroot",
-    "postCreateCommand": "npm install -g intelephense && ln -sf .devcontainer/AGENTS.md AGENTS.md && ln -sf .devcontainer/AGENTS.md CLAUDE.md && ln -sfn .devcontainer/.claude .claude",
+    "remoteEnv": {
+        "XDG_DATA_HOME": "/home/nonroot/.local/share",
+        "XDG_CONFIG_HOME": "/home/nonroot/.config"
+    },
+    "postCreateCommand": "npm install -g intelephense && ln -sf .devcontainer/AGENTS.md AGENTS.md",
     "postStartCommand": "sudo .devcontainer/init-firewall.sh",
     "customizations": {
         "vscode": {
             "extensions": [
-                "anthropic.claude-code",
+                "kilocode.kilo-code",
                 "bmewburn.vscode-intelephense-client",
                 "xdebug.php-debug"
             ],
             "settings": {
-                "claudeCode.allowDangerouslySkipPermissions": true,
-                "claudeCode.initialPermissionMode": "bypassPermissions",
                 "launch": {
                     "version": "0.2.0",
                     "configurations": [

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -9,6 +9,10 @@
 #   - Replaced per-domain IP resolution with dnsmasq --ipset to handle CDN IP rotation:
 #     dnsmasq intercepts all DNS queries and adds resolved IPs for allowed domains to the
 #     ipset dynamically, so the ipset is always current regardless of CDN IP rotation.
+#
+# Locks down the coding agent's outbound network access: only the domains listed in the
+# dnsmasq `ipset=` block (plus GitHub CIDRs and private networks) are reachable. Local model
+# runtimes (e.g. Ollama on the host) are reached via the already-allowed host gateway IP.
 set -euo pipefail
 IFS=$'\n\t'
 
@@ -96,7 +100,7 @@ listen-address=127.0.0.2
 bind-interfaces
 # Populate the allowed-domains ipset with every IP returned when resolving
 # any of these domains (or their subdomains)
-ipset=/github.com/anthropic.com/sentry.io/statsig.com/registry.npmjs.org/packagist.org/cdn.jsdelivr.net/marketplace.visualstudio.com/vscode.blob.core.windows.net/update.code.visualstudio.com/allowed-domains
+ipset=/github.com/registry.npmjs.org/packagist.org/cdn.jsdelivr.net/marketplace.visualstudio.com/vscode.blob.core.windows.net/update.code.visualstudio.com/allowed-domains
 EOF
 
 # Ensure idempotency when run as a postStartCommand: stop any existing dnsmasq.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 A [Docker](https://www.docker.com/)-based installer and runtime for the [Symfony](https://symfony.com) web framework,
 with [FrankenPHP](https://frankenphp.dev) and [Caddy](https://caddyserver.com/) inside!
 
-Specially tailored for coding agents: ships with a [Dev Container](https://containers.dev/) configuration
-that lets [Claude Code](https://claude.ai/claude-code) (and other AI coding assistants) run in fully autonomous
-mode inside a sandboxed environment.
+Tailored for coding agents: Includes a Dev Container configuration enabling [Kilo Code](https://kilocode.ai) (and other AI assistants like Claude Code)
+to run local or remote models autonomously inside a sandboxed environment.
 
 ![CI](https://github.com/dunglas/symfony-docker/workflows/CI/badge.svg)
 
@@ -31,7 +30,7 @@ mode inside a sandboxed environment.
 - Native [XDebug](docs/xdebug.md) integration
 - [Hot Reloading](https://frankenphp.dev/docs/hot-reload/)
 - [Dev Container](https://containers.dev/) support, optimized for AI coding agents
-- [AI coding agents](docs/agents.md) with sandboxing out of the box
+- [Coding agents](docs/agents.md) (Kilo Code or Claude Code) support with local + remote model support and sandboxing out of the box
 - Rootless, slim production image
 
 **Enjoy!**

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -59,7 +59,7 @@ point Kilo Code at it from inside the container.
       "provider": {
          "ollama": {
             "options": {
-               "baseURL": "http://localhost:11434/v1"
+               "baseURL": "http://host.docker.internal:11434/v1"
             },
             "models": {
                "qwen3-coder-next": {

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -3,8 +3,13 @@
 This project ships with a [Dev Container](https://containers.dev/) configuration that enables
 AI coding agents to run autonomously inside a sandboxed environment with network-level restrictions.
 
-[Claude Code](https://claude.ai/claude-code) is pre-installed and configured out of the box,
-but the setup also works with other agents such as [OpenAI Codex CLI](https://github.com/openai/codex)
+[Kilo Code](https://kilocode.ai), an open source coding agent, is pre-installed and configured out
+of the box. It works with both **local models** (via [Ollama](https://ollama.com) or
+[LM Studio](https://lmstudio.ai), so your code never leaves your machine) and **remote providers**
+(any OpenAI-compatible API including Anthropic, OpenRouter, and more). You pick the model.
+
+The setup also works with other agents such as [Claude Code](https://claude.ai/claude-code)
+(see [Switching to Claude Code](#switching-to-claude-code)), [OpenAI Codex CLI](https://github.com/openai/codex),
 and [opencode](https://opencode.ai).
 
 This setup is ideal for letting AI agents work on your Symfony project autonomously
@@ -14,7 +19,7 @@ while ensuring they cannot reach arbitrary internet hosts.
 
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/) (or any Docker-compatible runtime)
 - [Visual Studio Code](https://code.visualstudio.com/) with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension
-- A valid subscription or API key for the agent you want to use
+- A model to drive the agent: a local runtime (Ollama / LM Studio) or an API key for a remote provider
 
 ## Quick Start
 
@@ -24,26 +29,68 @@ while ensuring they cannot reach arbitrary internet hosts.
    **Dev Containers: Reopen in Container**.
 3. Wait for the container to build and start. On each container start, the
    `postStartCommand` configures the firewall automatically.
-4. Claude Code is pre-installed and configured in YOLO mode — open the Claude Code
-   panel in Visual Studio Code or run `claude` in the integrated terminal to start using it.
+4. Open the **Kilo Code** panel in Visual Studio Code and choose a model - see
+   [Choosing a model](#choosing-a-model) below.
 
-That's it. Claude Code will run without permission prompts, and the firewall ensures
-network access is restricted to only the necessary services.
+That's it. Inside the container, Kilo Code runs with **auto-approval enabled** (a
+`~/.config/kilo/kilo.jsonc` written on create sets `"permission": { "*": "allow" }`), so it acts
+without confirmation prompts. This is safe here because the firewall restricts network access to
+only the necessary services. The config is container-scoped and does not affect Kilo Code on your
+host.
 
-## What Is YOLO Mode?
+## Choosing a model
 
-YOLO mode (also known as "bypass permissions" mode) allows Claude Code to execute
-commands, edit files, and perform actions without asking for confirmation at each step.
-This dramatically speeds up autonomous coding workflows.
+Kilo Code needs a model provider. Configure it once in the Kilo Code panel
+(**Settings** → **API Provider**).
 
-The Dev Container configuration enables this via two Visual Studio Code settings:
+### Local model (private, no API cost)
 
-```json
-{
-  "claudeCode.allowDangerouslySkipPermissions": true,
-  "claudeCode.initialPermissionMode": "bypassPermissions"
-}
-```
+Run the model on your **host** machine (so it can use the host GPU - Apple Metal or NVIDIA) and
+point Kilo Code at it from inside the container.
+
+1. Install [Ollama](https://ollama.com) on the host then pull a coding model, e.g. `qwen3-coder` / `devstral` (requires a capable GPU).
+2. Create a  `kilo.jsonc` in the directory root:
+
+   ```jsonc
+   {
+      "$schema": "https://app.kilo.ai/config.json",
+      "model": "ollama/qwen3-coder-next", // change with your model
+
+      "provider": {
+         "ollama": {
+            "options": {
+               "baseURL": "http://localhost:11434/v1"
+            },
+            "models": {
+               "qwen3-coder-next": {
+                  "name": "Qwen3-Coder-Next (local)",
+                  "tool_call": true, // required for agent mode (file edits, terminal)
+                  "reasoning": false,
+                  "limit": {
+                     "context": 131072, // Kilo's compaction bookkeeping
+                     "output": 32000
+                  }
+               }
+            }
+         }
+      }
+   }
+   ```
+
+See Kilo Code's own guides for details:
+[Local models](https://kilocode.ai/docs/advanced-usage/local-models) ·
+[Ollama provider](https://kilo.ai/docs/ai-providers/ollama).
+
+### Remote model
+
+To use a hosted provider (OpenAI-compatible, Anthropic, OpenRouter, etc.):
+
+1. Add the provider's API domain to the firewall allowlist in `.devcontainer/init-firewall.sh`
+   (see [Customizing the Allowed Domains](#customizing-the-allowed-domains)), e.g. `api.openai.com`
+   or `openrouter.ai`. Rebuild the Dev Container.
+2. In the Kilo Code panel, select the provider and enter your API key.
+
+See [Kilo Code's AI providers reference](https://kilo.ai/docs/ai-providers) for the full list.
 
 ## Network Sandboxing
 
@@ -51,17 +98,18 @@ Running an AI agent with full autonomy requires guardrails. The Dev Container in
 a firewall script (`.devcontainer/init-firewall.sh`) that locks down outbound network
 access using `iptables` and `ipset`. Only the following destinations are allowed:
 
-| Destination                                       | Reason                          |
-| ------------------------------------------------- | ------------------------------- |
-| GitHub (`github.com`, `api.github.com`)           | Git operations, API access      |
-| Anthropic (`anthropic.com`)                       | Claude Code backend             |
-| npm registry (`registry.npmjs.org`)               | Node.js dependencies            |
-| Packagist (`packagist.org`, `repo.packagist.org`) | PHP/Composer dependencies       |
-| Visual Studio Code Marketplace                    | Extension downloads             |
-| Sentry, Statsig                                   | Telemetry (used by Claude Code) |
-| Host gateway IP                                   | Communication with Docker host  |
+| Destination                                          | Reason                            |
+| ---------------------------------------------------- | -------------------------------   |
+| GitHub (`github.com`, `api.github.com`)              | Git operations, API access        |
+| npm registry (`registry.npmjs.org`)                  | Node.js dependencies              |
+| Packagist (`packagist.org`, `repo.packagist.org`)    | PHP/Composer dependencies         |
+| jsDelivr (`cdn.jsdelivr.net`)                        | AssetMapper assets                |
+| Visual Studio Code Marketplace                       | Extension downloads               |
+| Host gateway IP                                      | Docker host + local model runtime |
+| Private networks (`10/8`, `172.16/12`, `192.168/16`) | Docker Compose services           |
 
-All other outbound connections are **rejected**. The firewall uses
+All other outbound connections are **rejected**. A **local** model reached on the host gateway
+needs no allowlist entry; a **remote** provider does (see below). The firewall uses
 [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) to dynamically resolve
 and whitelist IPs for allowed domains, handling CDN IP rotation gracefully.
 
@@ -71,16 +119,63 @@ so you can access your Symfony app from the host browser.
 
 ## Customizing the Allowed Domains
 
-To allow additional domains (e.g., a private registry or API), edit
+To allow additional domains (e.g., a private registry or a remote model provider), edit
 `.devcontainer/init-firewall.sh` and add them to the `ipset` line in the
 dnsmasq configuration section:
 
 ```bash
 # Domains are '/'-separated, ending with the ipset name
-ipset=/github.com/anthropic.com/your-domain.com/allowed-domains
+ipset=/github.com/api.openai.com/your-domain.com/allowed-domains
 ```
 
 Then rebuild the Dev Container for the changes to take effect.
+
+## Switching to Claude Code
+
+To use [Claude Code](https://claude.ai/claude-code) instead of (or alongside) Kilo Code, add
+the four pieces below and rebuild the Dev Container.
+
+1. **Add the devcontainer feature** in `.devcontainer/devcontainer.json`:
+
+   ```json
+   "features": {
+       "ghcr.io/devcontainers/features/node:1": {},
+       "ghcr.io/devcontainers-extra/features/claude-code:2": {}
+   }
+   ```
+
+2. **Install the extension and enable YOLO mode** in the same file's `customizations.vscode` block:
+
+   ```json
+   "extensions": [
+       "anthropic.claude-code",
+       "bmewburn.vscode-intelephense-client",
+       "xdebug.php-debug"
+   ],
+   "settings": {
+       "claudeCode.allowDangerouslySkipPermissions": true,
+       "claudeCode.initialPermissionMode": "bypassPermissions",
+       "launch": { "...": "..." }
+   }
+   ```
+
+   YOLO mode (also called "bypass permissions" mode) lets Claude Code execute commands, edit files,
+   and act without confirmation at each step, which speeds up autonomous workflows.
+
+3. **Symlink the project context** so Claude Code picks it up, by appending to `postCreateCommand`:
+
+   ```jsonc
+   "postCreateCommand": "npm install -g intelephense && ln -sf .devcontainer/AGENTS.md AGENTS.md && ln -sf .devcontainer/AGENTS.md CLAUDE.md && ln -sfn .devcontainer/.claude .claude",
+   ```
+
+4. **Allow Anthropic's domains** in `.devcontainer/init-firewall.sh` by adding them to the `ipset`
+   line (`sentry.io` and `statsig.com` are used by Claude Code's telemetry):
+
+   ```bash
+   ipset=/github.com/anthropic.com/sentry.io/statsig.com/registry.npmjs.org/.../allowed-domains
+   ```
+
+Then run `claude` in the integrated terminal, or open the Claude Code panel.
 
 ## Using Other Agents
 
@@ -123,7 +218,7 @@ For any other agent, follow the same pattern:
 
 1. Add the agent's API domain(s) to the firewall allowlist.
 2. Install the agent inside the container.
-3. Run it — the `.devcontainer/AGENTS.md` file provides project context
+3. Run it - the `.devcontainer/AGENTS.md` file provides project context
    to agents that support the convention.
 
 ## Using Without Visual Studio Code
@@ -135,24 +230,22 @@ The Dev Container configuration works with any tool that supports the
 - [GitHub Codespaces](https://github.com/features/codespaces)
 - JetBrains IDEs (with the Dev Containers plugin)
 
-To use Claude Code from the terminal inside the container:
-
-```console
-claude
-```
-
-To start directly in YOLO mode from the CLI:
-
-```console
-claude --dangerously-skip-permissions
-```
+Kilo Code is a Visual Studio Code extension; from a plain terminal inside the container, use a
+CLI agent instead (see [Using Other Agents](#using-other-agents)).
 
 ## Troubleshooting
 
 ### Firewall blocks a required domain
 
 If your agent or Composer/npm fails to reach a service, check the firewall
-logs and add the domain to the dnsmasq allowlist as described above.
+logs and add the domain to the dnsmasq allowlist as described above. A remote model provider
+needs its API domain whitelisted; a local model on the host gateway does not.
+
+### Kilo Code can't reach a local model
+
+Confirm the runtime is listening on the host (`curl http://localhost:11434/api/tags` on the host),
+that Kilo Code's base URL is `http://host.docker.internal:11434`, and - on Linux native Docker -
+that `host.docker.internal` resolves (see the note under [Local model](#local-model-private-no-api-cost)).
 
 ### Container fails to start
 


### PR DESCRIPTION
Closes #943 

Ship the open source Kilo Code extension as the pre-installed agent. It drives local models (Ollama/LM Studio via the host gateway) or remote providers, so the sandbox no longer needs Anthropic's domains by default. Document how to add Claude Code back in docs/agents.md.