### PR TITLE
Fix PHP TLS cert verification in prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,7 @@ COPY --from=frankenphp_prod_builder /etc/ssl/openssl.cnf /etc/ssl/openssl.cnf
 COPY --from=frankenphp_prod_builder /usr/bin/file /usr/bin/file
 COPY --from=frankenphp_prod_builder /usr/lib/file/magic.mgc /usr/lib/file/magic.mgc
 
-ENV  OPENSSL_CONF=/etc/ssl/openssl.cnf XDG_CONFIG_HOME=/config XDG_DATA_HOME=/data
+ENV  OPENSSL_CONF=/etc/ssl/openssl.cnf XDG_CONFIG_HOME=/config XDG_DATA_HOME=/data SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 RUN <<-EOF
 	mkdir -p /data/caddy /config/caddy


### PR DESCRIPTION
Native PHP HTTPS streams failed in the production image with certificate verify failed, notably when using fopen() on remote HTTPS files.

 ### Reproduction
  
  ```bash
  docker build --target frankenphp_prod -t verify-prod .
  docker run --rm verify-prod php -r 'var_dump(fopen("https://www.google.com", "r"));'
  # Symfony v8.1.0 (env: prod, debug: false)
  # PHP app ready!
  # PHP Warning:  fopen(): SSL operation failed with code 1. OpenSSL Error messages:
  # error:0A000086:SSL routines::certificate verify failed in Command line code on line 1
  # PHP Warning:  fopen(): Failed to enable crypto in Command line code on line 1
  # PHP Warning:  fopen(https://www.google.com): Failed to open stream: operation failed in Command line code on line 1
  # bool(false)
  ```
  
The image contains the CA bundle at `/etc/ssl/certs/ca-certificates.crt` but OpenSSL looks by default for `/usr/lib/ssl/cert.pem` which is missing in the slim Debian image.

### Fix
Set `SSL_CERT_FILE` so OpenSSL and native PHP streams use the CA bundle already present in the image:

```dockerfile
ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
```