### PR TITLE
Add PDO driver for PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,9 @@ ENV COMPOSER_ALLOW_SUPERUSER=1
 ENV PHP_INI_SCAN_DIR=":$PHP_INI_DIR/app.conf.d"
 
 ###> recipes ###
+###> doctrine/doctrine-bundle ###
+RUN install-php-extensions pdo_pgsql
+###< doctrine/doctrine-bundle ###
 ###< recipes ###
 
 COPY --link frankenphp/conf.d/10-app.ini $PHP_INI_DIR/app.conf.d/


### PR DESCRIPTION
Trying to setup the default PostgreSQL database as in the documentation here:

https://symfony.com/doc/current/the-fast-track/en/7-database.html

Results in PHP container log errors:

```
Still waiting for database to be ready... Or maybe the database is not reachable. 59 attempts left.
```

The PHP container was failing because the PostgreSQL PDO extension was missing inside the image and Symfony’s readiness check reported: `could not find driver`

I rebuilt the PHP image and verified the fix and the container now has pdo_pgsql installed and loaded
the Symfony readiness check completed successfully with: `The database is now ready and reachable`