### PR TITLE
docs: fix Alpine ash shell options

### DIFF
--- a/docs/alpine.md
+++ b/docs/alpine.md
@@ -15,7 +15,7 @@ To switch to Alpine-based images, apply the following changes to the `Dockerfile
 +FROM dunglas/frankenphp:1-php8.5-alpine AS frankenphp_upstream
 
 -SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
-+SHELL ["/bin/ash", "-euxo", "-c"]
++SHELL ["/bin/ash", "-eux", "-o", "pipefail", "-c"]
 
 -# hadolint ignore=DL3008
 -RUN <<-EOF
@@ -52,7 +52,7 @@ To switch to Alpine-based images, apply the following changes to the `Dockerfile
 +FROM alpine:3 AS frankenphp_prod
 
 -SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
-+SHELL ["/bin/ash", "-euxo", "-c"]
++SHELL ["/bin/ash", "-eux", "-o", "pipefail", "-c"]
 
 -COPY --from=frankenphp_prod_builder /usr/lib/file/magic.mgc /usr/lib/file/magic.mgc
 +COPY --from=frankenphp_prod_builder /usr/share/misc/magic.mgc /usr/share/misc/magic.mgc


### PR DESCRIPTION
## Summary

- fix Alpine documentation shell option syntax for `ash`
- use explicit `-o pipefail` instead of `-euxo -c`

```sh
## KO
ash -euxo -c 'echo KO'
ash: illegal option -o -c

## OK
ash -eux -o pipefail -c 'echo OK'
+ echo OK
OK
```

## Tests

- Not run; documentation-only change.