### PR TITLE
chore: reduce verbosity of super-linter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,9 @@ jobs:
         env:
           GITHUB_ACTIONS_CONFIG_FILE: actionlint.yaml
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LOG_LEVEL: NOTICE
+          SUPPRESS_OUTPUT_ON_SUCCESS: true
+          SUPPRESS_POSSUM: true
           VALIDATE_CHECKOV: false
           VALIDATE_TRIVY: false
           VALIDATE_BIOME_FORMAT: false


### PR DESCRIPTION
The default output of super-linter is too verbose.